### PR TITLE
Update namespace name to reflect library name

### DIFF
--- a/include/array_value_node.hpp
+++ b/include/array_value_node.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace conf_file
+namespace libconfigfile
 {
     class array_value_node : public value_node
     {

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace conf_file
+namespace libconfigfile
 {
     class config
     {

--- a/include/end_value_node.hpp
+++ b/include/end_value_node.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace conf_file
+namespace libconfigfile
 {
     class end_value_node : public value_node
     {

--- a/include/file.hpp
+++ b/include/file.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-namespace conf_file
+namespace libconfigfile
 {
     class file_pos;
 

--- a/include/float_end_value_node.hpp
+++ b/include/float_end_value_node.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <iostream>
 
-namespace conf_file
+namespace libconfigfile
 {
     class float_end_value_node : public end_value_node
     {

--- a/include/integer_end_value_node.hpp
+++ b/include/integer_end_value_node.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <iostream>
 
-namespace conf_file
+namespace libconfigfile
 {
     class integer_end_value_node : public end_value_node
     {

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 
-namespace conf_file
+namespace libconfigfile
 {
     class node
     {

--- a/include/node_ptr.hpp
+++ b/include/node_ptr.hpp
@@ -6,7 +6,7 @@
 #include <concepts>
 #include <utility>
 
-namespace conf_file
+namespace libconfigfile
 {
     template<typename node_t>
     concept is_node = std::derived_from<node_t, node>;

--- a/include/node_types.hpp
+++ b/include/node_types.hpp
@@ -1,7 +1,7 @@
 #ifndef CONF_FILE_NODE_TYPES_HPP
 #define CONF_FILE_NODE_TYPES_HPP
 
-namespace conf_file
+namespace libconfigfile
 {
     enum class actual_node_type
     {

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace conf_file
+namespace libconfigfile
 {
     class section_node : public node
     {

--- a/include/semantic_error.hpp
+++ b/include/semantic_error.hpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace conf_file
+namespace libconfigfile
 {
     class semantic_error : public std::runtime_error
     {

--- a/include/string_end_value_node.hpp
+++ b/include/string_end_value_node.hpp
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <string>
 
-namespace conf_file
+namespace libconfigfile
 {
     class string_end_value_node : public end_value_node
     {

--- a/include/syntax_error.hpp
+++ b/include/syntax_error.hpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace conf_file
+namespace libconfigfile
 {
     class syntax_error : public std::runtime_error
     {

--- a/include/value_node.hpp
+++ b/include/value_node.hpp
@@ -6,7 +6,7 @@
 
 #include <cstddef>
 
-namespace conf_file
+namespace libconfigfile
 {
     class value_node : public node
     {

--- a/src/array_value_node.cpp
+++ b/src/array_value_node.cpp
@@ -8,76 +8,76 @@
 #include <utility>
 #include <vector>
 
-conf_file::array_value_node::array_value_node()
+libconfigfile::array_value_node::array_value_node()
     : m_value{}
 {
 }
 
-conf_file::array_value_node::array_value_node(const value_t& value)
+libconfigfile::array_value_node::array_value_node(const value_t& value)
     : m_value{ value }
 {
 }
 
-conf_file::array_value_node::array_value_node(value_t&& value)
+libconfigfile::array_value_node::array_value_node(value_t&& value)
     : m_value{ std::move(value) }
 {
 }
 
-conf_file::array_value_node::array_value_node(const array_value_node& other)
+libconfigfile::array_value_node::array_value_node(const array_value_node& other)
     : m_value{ other.m_value }
 {
 }
 
-conf_file::array_value_node::array_value_node(array_value_node&& other)
+libconfigfile::array_value_node::array_value_node(array_value_node&& other)
     : m_value{ std::move(other.m_value) }
 {
 }
 
-conf_file::array_value_node::~array_value_node()
+libconfigfile::array_value_node::~array_value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::array_value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::array_value_node::get_actual_node_type() const
 {
     return actual_node_type::ARRAY_VALUE_NODE;
 }
 
-conf_file::array_value_node* conf_file::array_value_node::create_new() const
+libconfigfile::array_value_node* libconfigfile::array_value_node::create_new() const
 {
     return new array_value_node{};
 }
 
-conf_file::array_value_node* conf_file::array_value_node::create_clone() const
+libconfigfile::array_value_node* libconfigfile::array_value_node::create_clone() const
 {
     return new array_value_node{ *this };
 }
 
-conf_file::value_node_type conf_file::array_value_node::get_value_node_type() const
+libconfigfile::value_node_type libconfigfile::array_value_node::get_value_node_type() const
 {
     return value_node_type::ARRAY;
 }
 
-const conf_file::array_value_node::value_t& conf_file::array_value_node::get() const
+const libconfigfile::array_value_node::value_t& libconfigfile::array_value_node::get() const
 {
     return m_value;
 }
 
-conf_file::array_value_node::value_t& conf_file::array_value_node::get()
+libconfigfile::array_value_node::value_t& libconfigfile::array_value_node::get()
 {
     return m_value;
 }
 
-void conf_file::array_value_node::set(const value_t& value)
+void libconfigfile::array_value_node::set(const value_t& value)
 {
     m_value = value;
 }
 
-void conf_file::array_value_node::set(value_t&& value)
+void libconfigfile::array_value_node::set(value_t&& value)
 {
     m_value = std::move(value);
 }
 
-conf_file::array_value_node& conf_file::array_value_node::operator=(const array_value_node& other)
+libconfigfile::array_value_node& libconfigfile::array_value_node::operator=(const array_value_node& other)
 {
     if (this == &other)
     {
@@ -89,7 +89,7 @@ conf_file::array_value_node& conf_file::array_value_node::operator=(const array_
     return *this;
 }
 
-conf_file::array_value_node& conf_file::array_value_node::operator=(array_value_node&& other)
+libconfigfile::array_value_node& libconfigfile::array_value_node::operator=(array_value_node&& other)
 {
     if (this == &other)
     {
@@ -102,21 +102,21 @@ conf_file::array_value_node& conf_file::array_value_node::operator=(array_value_
 }
 
 
-conf_file::array_value_node& conf_file::array_value_node::operator=(const value_t& value)
+libconfigfile::array_value_node& libconfigfile::array_value_node::operator=(const value_t& value)
 {
     m_value = value;
 
     return *this;
 }
 
-conf_file::array_value_node& conf_file::array_value_node::operator=(value_t&& value)
+libconfigfile::array_value_node& libconfigfile::array_value_node::operator=(value_t&& value)
 {
     m_value = std::move(value);
 
     return *this;
 }
 
-conf_file::array_value_node::operator value_t() const
+libconfigfile::array_value_node::operator value_t() const
 {
     return m_value;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,36 +23,36 @@
 #include <utility>
 #include <vector>
 
-conf_file::config::config()
+libconfigfile::config::config()
     : m_raw_file_contents{},
       m_values{}
 {
 }
 
-conf_file::config::config(const std::string& file_name)
+libconfigfile::config::config(const std::string& file_name)
     : m_raw_file_contents{ file_name, false },
       m_values{}
 {
     parse_file();
 }
 
-conf_file::config::config(const config& other)
+libconfigfile::config::config(const config& other)
     : m_raw_file_contents{ other.m_raw_file_contents },
       m_values{ other.m_values }
 {
 }
 
-conf_file::config::config(config&& other)
+libconfigfile::config::config(config&& other)
     : m_raw_file_contents{ std::move(other.m_raw_file_contents) },
       m_values{ std::move(other.m_values) }
 {
 }
 
-conf_file::config::~config()
+libconfigfile::config::~config()
 {
 }
 
-conf_file::config& conf_file::config::operator=(const config& other)
+libconfigfile::config& libconfigfile::config::operator=(const config& other)
 {
     if (this == &other)
     {
@@ -65,7 +65,7 @@ conf_file::config& conf_file::config::operator=(const config& other)
     return *this;
 }
 
-conf_file::config& conf_file::config::operator=(config&& other)
+libconfigfile::config& libconfigfile::config::operator=(config&& other)
 {
     if (this == &other)
     {
@@ -78,7 +78,7 @@ conf_file::config& conf_file::config::operator=(config&& other)
     return *this;
 }
 
-void conf_file::config::parse_file()
+void libconfigfile::config::parse_file()
 {
     static const auto is_whitespace{ [](char c)
     {
@@ -133,7 +133,7 @@ void conf_file::config::parse_file()
     }
 }
 
-void conf_file::config::parse_directive(file_pos& cur_pos)
+void libconfigfile::config::parse_directive(file_pos& cur_pos)
 {
     std::string directive_line{ m_raw_file_contents.get_line(cur_pos) };
     std::string::size_type line_pos{ cur_pos.get_char() };
@@ -183,7 +183,7 @@ void conf_file::config::parse_directive(file_pos& cur_pos)
     }
 }
 
-void conf_file::config::parse_include_directive(file_pos& cur_pos, const std::string& args)
+void libconfigfile::config::parse_include_directive(file_pos& cur_pos, const std::string& args)
 {
     if (args[0] != '"')
     {
@@ -192,12 +192,12 @@ void conf_file::config::parse_include_directive(file_pos& cur_pos, const std::st
     //TODO continue from here
 }
 
-bool conf_file::config::is_pos_located_on_occurence_of(const file_pos& pos, const std::string& str)
+bool libconfigfile::config::is_pos_located_on_occurence_of(const file_pos& pos, const std::string& str)
 {
     return ((pos.get_char()) == (m_raw_file_contents.get_line(pos).find(str, pos.get_char())));
 }
 
-std::string conf_file::config::get_substr_between_indices(const std::string& str, const std::string::size_type start, const std::string::size_type end)
+std::string libconfigfile::config::get_substr_between_indices(const std::string& str, const std::string::size_type start, const std::string::size_type end)
 {
     return str.substr((start), ((end - start) + 1));
 }

--- a/src/end_value_node.cpp
+++ b/src/end_value_node.cpp
@@ -7,16 +7,16 @@
 #include <cstddef>
 #include <utility>
 
-conf_file::end_value_node::~end_value_node()
+libconfigfile::end_value_node::~end_value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::end_value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::end_value_node::get_actual_node_type() const
 {
     return actual_node_type::END_VALUE_NODE;
 }
 
-conf_file::value_node_type conf_file::end_value_node::get_value_node_type() const
+libconfigfile::value_node_type libconfigfile::end_value_node::get_value_node_type() const
 {
     return value_node_type::END_VALUE;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -8,56 +8,56 @@
 #include <vector>
 #include <utility>
 
-conf_file::file::file()
+libconfigfile::file::file()
     : m_file_path{},
       m_file_contents{}
 {
 }
 
-conf_file::file::file(const std::string& file_path, bool insert_newlines/*= true*/)
+libconfigfile::file::file(const std::string& file_path, bool insert_newlines/*= true*/)
     : m_file_path{ file_path },
       m_file_contents{ read_file(m_file_path, insert_newlines) }
 {
 }
 
-conf_file::file::file(std::string&& file_path, bool insert_newlines/*= true*/)
+libconfigfile::file::file(std::string&& file_path, bool insert_newlines/*= true*/)
     : m_file_path{ std::move(file_path) },
       m_file_contents{ read_file(m_file_path, insert_newlines) }
 {
 }
 
-conf_file::file::file(const file& other)
+libconfigfile::file::file(const file& other)
     : m_file_path{ other.m_file_path },
       m_file_contents{ other.m_file_contents }
 {
 }
 
-conf_file::file::file(file&& other)
+libconfigfile::file::file(file&& other)
     : m_file_path{ std::move(other.m_file_path) },
       m_file_contents{ std::move(other.m_file_contents) }
 {
 }
 
-conf_file::file::~file()
+libconfigfile::file::~file()
 {
 }
 
-bool conf_file::file::is_paired(const file_pos& pos) const
+bool libconfigfile::file::is_paired(const file_pos& pos) const
 {
     return (this == pos.get_paired_file());
 }
 
-std::string conf_file::file::get_file_path() const
+std::string libconfigfile::file::get_file_path() const
 {
     return m_file_path;
 }
 
-conf_file::file_pos conf_file::file::create_file_pos() const
+libconfigfile::file_pos libconfigfile::file::create_file_pos() const
 {
     return file_pos{ this };
 }
 
-const char& conf_file::file::get_char(const file_pos& pos) const
+const char& libconfigfile::file::get_char(const file_pos& pos) const
 {
     if (pos.get_paired_file() != this)
     {
@@ -77,7 +77,7 @@ const char& conf_file::file::get_char(const file_pos& pos) const
     return m_file_contents[pos.get_line()][pos.get_char()];
 }
 
-const std::string& conf_file::file::get_line(const file_pos& pos) const
+const std::string& libconfigfile::file::get_line(const file_pos& pos) const
 {
     if (pos.get_paired_file() != this)
     {
@@ -97,17 +97,17 @@ const std::string& conf_file::file::get_line(const file_pos& pos) const
     return m_file_contents[pos.get_line()];
 }
 
-const std::vector<std::string>& conf_file::file::get_array() const
+const std::vector<std::string>& libconfigfile::file::get_array() const
 {
     return m_file_contents;
 }
 
-std::vector<std::string>& conf_file::file::get_underlying()
+std::vector<std::string>& libconfigfile::file::get_underlying()
 {
     return m_file_contents;
 }
 
-conf_file::file& conf_file::file::operator=(const file& other)
+libconfigfile::file& libconfigfile::file::operator=(const file& other)
 {
     if (this == &other)
     {
@@ -120,7 +120,7 @@ conf_file::file& conf_file::file::operator=(const file& other)
     return *this;
 }
 
-conf_file::file& conf_file::file::operator=(file&& other)
+libconfigfile::file& libconfigfile::file::operator=(file&& other)
 {
     if (this == &other)
     {
@@ -133,7 +133,7 @@ conf_file::file& conf_file::file::operator=(file&& other)
     return *this;
 }
 
-const char& conf_file::file::operator[](const file_pos& pos) const
+const char& libconfigfile::file::operator[](const file_pos& pos) const
 {
     if (pos.get_paired_file() != this)
     {
@@ -153,7 +153,7 @@ const char& conf_file::file::operator[](const file_pos& pos) const
     return m_file_contents[pos.get_line()][pos.get_char()];
 }
 
-std::vector<std::string> conf_file::file::read_file(const std::string& file_path, const bool insert_newlines/*= false*/)
+std::vector<std::string> libconfigfile::file::read_file(const std::string& file_path, const bool insert_newlines/*= false*/)
 {
     std::ifstream input_file{ file_path };
 
@@ -180,7 +180,7 @@ std::vector<std::string> conf_file::file::read_file(const std::string& file_path
     return file_contents;
 }
 
-conf_file::file_pos::file_pos(const file* file_in_which_to_move)
+libconfigfile::file_pos::file_pos(const file* file_in_which_to_move)
     : m_file{ file_in_which_to_move },
       m_line{ 0 },
       m_char{ 0 },
@@ -193,7 +193,7 @@ conf_file::file_pos::file_pos(const file* file_in_which_to_move)
     }
 }
 
-conf_file::file_pos::file_pos(const file_pos& other)
+libconfigfile::file_pos::file_pos(const file_pos& other)
     : m_file{ other.m_file },
       m_line{ other.m_line },
       m_char{ other.m_char },
@@ -202,7 +202,7 @@ conf_file::file_pos::file_pos(const file_pos& other)
 {
 }
 
-conf_file::file_pos::file_pos(file_pos&& other)
+libconfigfile::file_pos::file_pos(file_pos&& other)
     : m_file{ std::move(other.m_file) },
       m_line{ std::move(other.m_line) },
       m_char{ std::move(other.m_char) },
@@ -211,41 +211,41 @@ conf_file::file_pos::file_pos(file_pos&& other)
 {
 }
 
-conf_file::file_pos::~file_pos()
+libconfigfile::file_pos::~file_pos()
 {
 }
 
-bool conf_file::file_pos::is_paired(const file& f) const
+bool libconfigfile::file_pos::is_paired(const file& f) const
 {
     return m_file == &f;
 }
 
-const conf_file::file* conf_file::file_pos::get_paired_file() const
+const libconfigfile::file* libconfigfile::file_pos::get_paired_file() const
 {
     return m_file;
 }
 
-bool conf_file::file_pos::is_bof() const
+bool libconfigfile::file_pos::is_bof() const
 {
     return m_bof;
 }
 
-bool conf_file::file_pos::is_eof() const
+bool libconfigfile::file_pos::is_eof() const
 {
     return m_eof;
 }
 
-size_t conf_file::file_pos::get_line() const
+size_t libconfigfile::file_pos::get_line() const
 {
     return m_line;
 }
 
-size_t conf_file::file_pos::get_char() const
+size_t libconfigfile::file_pos::get_char() const
 {
     return m_char;
 }
 
-void conf_file::file_pos::set_line(const size_t line_val)
+void libconfigfile::file_pos::set_line(const size_t line_val)
 {
     if (line_val >= m_file->get_array().size())
     {
@@ -257,7 +257,7 @@ void conf_file::file_pos::set_line(const size_t line_val)
     }
 }
 
-void conf_file::file_pos::set_char(const size_t char_val)
+void libconfigfile::file_pos::set_char(const size_t char_val)
 {
     if (char_val >= m_file->get_line(*this).size())
     {
@@ -269,7 +269,7 @@ void conf_file::file_pos::set_char(const size_t char_val)
     }
 }
 
-void conf_file::file_pos::goto_next_line(size_t lines_to_move/*= 1*/)
+void libconfigfile::file_pos::goto_next_line(size_t lines_to_move/*= 1*/)
 {
     if (lines_to_move == 0)
     {
@@ -295,7 +295,7 @@ void conf_file::file_pos::goto_next_line(size_t lines_to_move/*= 1*/)
     }
 }
 
-void conf_file::file_pos::goto_prev_line(size_t lines_to_move/*= 1*/)
+void libconfigfile::file_pos::goto_prev_line(size_t lines_to_move/*= 1*/)
 {
     if (lines_to_move == 0)
     {
@@ -321,7 +321,7 @@ void conf_file::file_pos::goto_prev_line(size_t lines_to_move/*= 1*/)
     }
 }
 
-void conf_file::file_pos::goto_next_char(size_t chars_to_move/*= 1*/)
+void libconfigfile::file_pos::goto_next_char(size_t chars_to_move/*= 1*/)
 {
     while (true)
     {
@@ -344,7 +344,7 @@ void conf_file::file_pos::goto_next_char(size_t chars_to_move/*= 1*/)
     }
 }
 
-void conf_file::file_pos::goto_prev_char(size_t chars_to_move/*= 1*/)
+void libconfigfile::file_pos::goto_prev_char(size_t chars_to_move/*= 1*/)
 {
     while (true)
     {
@@ -368,7 +368,7 @@ void conf_file::file_pos::goto_prev_char(size_t chars_to_move/*= 1*/)
     }
 }
 
-void conf_file::file_pos::goto_find_start(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_start(const std::string& to_find)
 {
     if (m_eof == true)
     {
@@ -400,7 +400,7 @@ void conf_file::file_pos::goto_find_start(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_find_end(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_end(const std::string& to_find)
 {
     if (m_eof == true)
     {
@@ -411,7 +411,7 @@ void conf_file::file_pos::goto_find_end(const std::string& to_find)
     goto_next_char(to_find.size());
 }
 
-void conf_file::file_pos::goto_rfind_start(const std::string& to_find)
+void libconfigfile::file_pos::goto_rfind_start(const std::string& to_find)
 {
     if (m_bof == true)
     {
@@ -443,7 +443,7 @@ void conf_file::file_pos::goto_rfind_start(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_rfind_end(const std::string& to_find)
+void libconfigfile::file_pos::goto_rfind_end(const std::string& to_find)
 {
     if (m_bof == true)
     {
@@ -454,7 +454,7 @@ void conf_file::file_pos::goto_rfind_end(const std::string& to_find)
     goto_next_char(to_find.size());
 }
 
-void conf_file::file_pos::goto_find_first_of(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_first_of(const std::string& to_find)
 {
     if (m_eof == true)
     {
@@ -486,13 +486,13 @@ void conf_file::file_pos::goto_find_first_of(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_find_first_of(const std::vector<char>& to_find)
+void libconfigfile::file_pos::goto_find_first_of(const std::vector<char>& to_find)
 {
     goto_find_first_of(std::string{ to_find.begin(), to_find.end() });
 }
 
 
-void conf_file::file_pos::goto_find_first_not_of(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_first_not_of(const std::string& to_find)
 {
     if (m_eof == true)
     {
@@ -524,12 +524,12 @@ void conf_file::file_pos::goto_find_first_not_of(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_find_first_not_of(const std::vector<char>& to_find)
+void libconfigfile::file_pos::goto_find_first_not_of(const std::vector<char>& to_find)
 {
     goto_find_first_not_of(std::string{ to_find.begin(), to_find.end() });
 }
 
-void conf_file::file_pos::goto_find_last_of(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_last_of(const std::string& to_find)
 {
     if (m_bof == true)
     {
@@ -561,12 +561,12 @@ void conf_file::file_pos::goto_find_last_of(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_find_last_of(const std::vector<char>& to_find)
+void libconfigfile::file_pos::goto_find_last_of(const std::vector<char>& to_find)
 {
     goto_find_last_of(std::string{ to_find.begin(), to_find.end() });
 }
 
-void conf_file::file_pos::goto_find_last_not_of(const std::string& to_find)
+void libconfigfile::file_pos::goto_find_last_not_of(const std::string& to_find)
 {
     if (m_bof == true)
     {
@@ -600,12 +600,12 @@ void conf_file::file_pos::goto_find_last_not_of(const std::string& to_find)
     }
 }
 
-void conf_file::file_pos::goto_find_last_not_of(const std::vector<char>& to_find)
+void libconfigfile::file_pos::goto_find_last_not_of(const std::vector<char>& to_find)
 {
     goto_find_last_not_of(std::string{ to_find.begin(), to_find.end() });
 }
 
-void conf_file::file_pos::goto_end_of_whitespace(const std::string& whitespace_chars/*= " \t"*/)
+void libconfigfile::file_pos::goto_end_of_whitespace(const std::string& whitespace_chars/*= " \t"*/)
 {
     if (m_eof == true)
     {
@@ -655,12 +655,12 @@ void conf_file::file_pos::goto_end_of_whitespace(const std::string& whitespace_c
     }
 }
 
-void conf_file::file_pos::goto_end_of_whitespace(const std::vector<char>& whitespace_chars)
+void libconfigfile::file_pos::goto_end_of_whitespace(const std::vector<char>& whitespace_chars)
 {
     goto_end_of_whitespace(std::string{ whitespace_chars.begin(), whitespace_chars.end() });
 }
 
-void conf_file::file_pos::goto_start_of_whitespace(const std::string& whitespace_chars/*= " \t"*/)
+void libconfigfile::file_pos::goto_start_of_whitespace(const std::string& whitespace_chars/*= " \t"*/)
 {
     if (m_bof == true)
     {
@@ -710,12 +710,12 @@ void conf_file::file_pos::goto_start_of_whitespace(const std::string& whitespace
     }
 }
 
-void conf_file::file_pos::goto_start_of_whitespace(const std::vector<char>& whitespace_chars)
+void libconfigfile::file_pos::goto_start_of_whitespace(const std::vector<char>& whitespace_chars)
 {
     goto_start_of_whitespace(std::string{ whitespace_chars.begin(), whitespace_chars.end() });
 }
 
-conf_file::file_pos& conf_file::file_pos::operator=(const file_pos& other)
+libconfigfile::file_pos& libconfigfile::file_pos::operator=(const file_pos& other)
 {
     if (this == &other)
     {
@@ -731,7 +731,7 @@ conf_file::file_pos& conf_file::file_pos::operator=(const file_pos& other)
     return *this;
 }
 
-conf_file::file_pos& conf_file::file_pos::operator=(file_pos&& other)
+libconfigfile::file_pos& libconfigfile::file_pos::operator=(file_pos&& other)
 {
     if (this == &other)
     {
@@ -747,87 +747,87 @@ conf_file::file_pos& conf_file::file_pos::operator=(file_pos&& other)
     return *this;
 }
 
-bool conf_file::file_pos::operator==(const file_pos& other) const
+bool libconfigfile::file_pos::operator==(const file_pos& other) const
 {
     return ((m_line == other.m_line) && (m_char == other.m_char));
 }
 
-bool conf_file::file_pos::operator!=(const file_pos& other) const
+bool libconfigfile::file_pos::operator!=(const file_pos& other) const
 {
     return (!(operator==(other)));
 }
 
-conf_file::file_pos& conf_file::file_pos::operator++()
+libconfigfile::file_pos& libconfigfile::file_pos::operator++()
 {
     goto_next_char();
     return *this;
 }
 
-conf_file::file_pos conf_file::file_pos::operator++(int)
+libconfigfile::file_pos libconfigfile::file_pos::operator++(int)
 {
     file_pos temp{ *this };
     operator++();
     return temp;
 }
 
-conf_file::file_pos& conf_file::file_pos::operator--()
+libconfigfile::file_pos& libconfigfile::file_pos::operator--()
 {
     goto_prev_char();
     return *this;
 }
 
-conf_file::file_pos conf_file::file_pos::operator--(int)
+libconfigfile::file_pos libconfigfile::file_pos::operator--(int)
 {
     file_pos temp{ *this };
     operator--();
     return temp;
 }
 
-conf_file::file_pos& conf_file::file_pos::operator+=(const size_t chars_to_move)
+libconfigfile::file_pos& libconfigfile::file_pos::operator+=(const size_t chars_to_move)
 {
     goto_next_char(chars_to_move);
     return *this;
 }
 
-conf_file::file_pos& conf_file::file_pos::operator-=(const size_t chars_to_move)
+libconfigfile::file_pos& libconfigfile::file_pos::operator-=(const size_t chars_to_move)
 {
     goto_prev_char(chars_to_move);
     return *this;
 }
 
-void conf_file::file_pos::set_bof()
+void libconfigfile::file_pos::set_bof()
 {
     m_bof = true;
     m_line = 0;
     m_char = 0;
 }
 
-void conf_file::file_pos::set_eof()
+void libconfigfile::file_pos::set_eof()
 {
     m_eof = true;
     m_line = (m_file->get_array().size() - 1);
     m_char = (m_file->get_line(*this).size() - 1);
 }
 
-conf_file::file_pos conf_file::operator+(file_pos pos, const size_t chars_to_move)
+libconfigfile::file_pos libconfigfile::operator+(file_pos pos, const size_t chars_to_move)
 {
     pos.goto_next_char(chars_to_move);
     return pos;
 }
 
-conf_file::file_pos conf_file::operator+(const size_t chars_to_move, file_pos pos)
+libconfigfile::file_pos libconfigfile::operator+(const size_t chars_to_move, file_pos pos)
 {
     pos.goto_next_char(chars_to_move);
     return pos;
 }
 
-conf_file::file_pos conf_file::operator-(file_pos pos, const size_t chars_to_move)
+libconfigfile::file_pos libconfigfile::operator-(file_pos pos, const size_t chars_to_move)
 {
     pos.goto_prev_char(chars_to_move);
     return pos;
 }
 
-conf_file::file_pos conf_file::operator-(const size_t chars_to_move, file_pos pos)
+libconfigfile::file_pos libconfigfile::operator-(const size_t chars_to_move, file_pos pos)
 {
     pos.goto_prev_char(chars_to_move);
     return pos;

--- a/src/float_end_value_node.cpp
+++ b/src/float_end_value_node.cpp
@@ -9,66 +9,66 @@
 #include <iostream>
 #include <utility>
 
-conf_file::float_end_value_node::float_end_value_node()
+libconfigfile::float_end_value_node::float_end_value_node()
     : m_value{}
 {
 }
 
-conf_file::float_end_value_node::float_end_value_node(const value_t value)
+libconfigfile::float_end_value_node::float_end_value_node(const value_t value)
     : m_value{ value }
 {
 }
 
-conf_file::float_end_value_node::float_end_value_node(const float_end_value_node& other)
+libconfigfile::float_end_value_node::float_end_value_node(const float_end_value_node& other)
     : m_value{ other.m_value }
 {
 }
 
-conf_file::float_end_value_node::float_end_value_node(float_end_value_node&& other)
+libconfigfile::float_end_value_node::float_end_value_node(float_end_value_node&& other)
     : m_value{ std::move(other.m_value) }
 {
 }
 
-conf_file::float_end_value_node::~float_end_value_node()
+libconfigfile::float_end_value_node::~float_end_value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::float_end_value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::float_end_value_node::get_actual_node_type() const
 {
     return actual_node_type::FLOAT_END_VALUE_NODE;
 }
 
-conf_file::float_end_value_node* conf_file::float_end_value_node::create_new() const
+libconfigfile::float_end_value_node* libconfigfile::float_end_value_node::create_new() const
 {
     return new float_end_value_node{};
 }
 
-conf_file::float_end_value_node* conf_file::float_end_value_node::create_clone() const
+libconfigfile::float_end_value_node* libconfigfile::float_end_value_node::create_clone() const
 {
     return new float_end_value_node{ *this };
 }
 
-conf_file::end_value_node_type conf_file::float_end_value_node::get_end_value_node_type() const
+libconfigfile::end_value_node_type libconfigfile::float_end_value_node::get_end_value_node_type() const
 {
     return end_value_node_type::FLOAT;
 }
 
-conf_file::float_end_value_node::value_t conf_file::float_end_value_node::get() const
+libconfigfile::float_end_value_node::value_t libconfigfile::float_end_value_node::get() const
 {
     return m_value;
 }
 
-conf_file::float_end_value_node::value_t& conf_file::float_end_value_node::get()
+libconfigfile::float_end_value_node::value_t& libconfigfile::float_end_value_node::get()
 {
     return m_value;
 }
 
-void conf_file::float_end_value_node::set(const value_t value)
+void libconfigfile::float_end_value_node::set(const value_t value)
 {
     m_value = value;
 }
 
-conf_file::float_end_value_node& conf_file::float_end_value_node::operator=(const float_end_value_node& other)
+libconfigfile::float_end_value_node& libconfigfile::float_end_value_node::operator=(const float_end_value_node& other)
 {
     if (this == &other)
     {
@@ -80,7 +80,7 @@ conf_file::float_end_value_node& conf_file::float_end_value_node::operator=(cons
     return *this;
 }
 
-conf_file::float_end_value_node& conf_file::float_end_value_node::operator=(float_end_value_node&& other)
+libconfigfile::float_end_value_node& libconfigfile::float_end_value_node::operator=(float_end_value_node&& other)
 {
     if (this == &other)
     {
@@ -92,25 +92,25 @@ conf_file::float_end_value_node& conf_file::float_end_value_node::operator=(floa
     return *this;
 }
 
-conf_file::float_end_value_node& conf_file::float_end_value_node::operator=(const value_t value)
+libconfigfile::float_end_value_node& libconfigfile::float_end_value_node::operator=(const value_t value)
 {
     m_value = value;
 
     return *this;
 }
 
-conf_file::float_end_value_node::operator value_t() const
+libconfigfile::float_end_value_node::operator value_t() const
 {
     return m_value;
 }
 
-std::ostream& conf_file::operator<<(std::ostream& out, const float_end_value_node& f)
+std::ostream& libconfigfile::operator<<(std::ostream& out, const float_end_value_node& f)
 {
     out << f.m_value;
     return out;
 }
 
-std::istream& conf_file::operator>>(std::istream& in, float_end_value_node& f)
+std::istream& libconfigfile::operator>>(std::istream& in, float_end_value_node& f)
 {
     in >> f.m_value;
     return in;

--- a/src/integer_end_value_node.cpp
+++ b/src/integer_end_value_node.cpp
@@ -10,66 +10,66 @@
 #include <iostream>
 #include <utility>
 
-conf_file::integer_end_value_node::integer_end_value_node()
+libconfigfile::integer_end_value_node::integer_end_value_node()
     : m_value{}
 {
 }
 
-conf_file::integer_end_value_node::integer_end_value_node(const value_t value)
+libconfigfile::integer_end_value_node::integer_end_value_node(const value_t value)
     : m_value{ value }
 {
 }
 
-conf_file::integer_end_value_node::integer_end_value_node(const integer_end_value_node& other)
+libconfigfile::integer_end_value_node::integer_end_value_node(const integer_end_value_node& other)
     : m_value{ other.m_value }
 {
 }
 
-conf_file::integer_end_value_node::integer_end_value_node(integer_end_value_node&& other)
+libconfigfile::integer_end_value_node::integer_end_value_node(integer_end_value_node&& other)
     : m_value{ std::move(other.m_value) }
 {
 }
 
-conf_file::integer_end_value_node::~integer_end_value_node()
+libconfigfile::integer_end_value_node::~integer_end_value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::integer_end_value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::integer_end_value_node::get_actual_node_type() const
 {
     return actual_node_type::INTEGER_END_VALUE_NODE;
 }
 
-conf_file::integer_end_value_node* conf_file::integer_end_value_node::create_new() const
+libconfigfile::integer_end_value_node* libconfigfile::integer_end_value_node::create_new() const
 {
     return new integer_end_value_node{};
 }
 
-conf_file::integer_end_value_node* conf_file::integer_end_value_node::create_clone() const
+libconfigfile::integer_end_value_node* libconfigfile::integer_end_value_node::create_clone() const
 {
     return new integer_end_value_node{ *this };
 }
 
-conf_file::end_value_node_type conf_file::integer_end_value_node::get_end_value_node_type() const
+libconfigfile::end_value_node_type libconfigfile::integer_end_value_node::get_end_value_node_type() const
 {
     return end_value_node_type::INTEGER;
 }
 
-conf_file::integer_end_value_node::value_t conf_file::integer_end_value_node::get() const
+libconfigfile::integer_end_value_node::value_t libconfigfile::integer_end_value_node::get() const
 {
     return m_value;
 }
 
-conf_file::integer_end_value_node::value_t& conf_file::integer_end_value_node::get()
+libconfigfile::integer_end_value_node::value_t& libconfigfile::integer_end_value_node::get()
 {
     return m_value;
 }
 
-void conf_file::integer_end_value_node::set(const value_t value)
+void libconfigfile::integer_end_value_node::set(const value_t value)
 {
     m_value = value;
 }
 
-conf_file::integer_end_value_node& conf_file::integer_end_value_node::operator=(const integer_end_value_node& other)
+libconfigfile::integer_end_value_node& libconfigfile::integer_end_value_node::operator=(const integer_end_value_node& other)
 {
     if (this == &other)
     {
@@ -81,7 +81,7 @@ conf_file::integer_end_value_node& conf_file::integer_end_value_node::operator=(
     return *this;
 }
 
-conf_file::integer_end_value_node& conf_file::integer_end_value_node::operator=(integer_end_value_node&& other)
+libconfigfile::integer_end_value_node& libconfigfile::integer_end_value_node::operator=(integer_end_value_node&& other)
 {
     if (this == &other)
     {
@@ -93,25 +93,25 @@ conf_file::integer_end_value_node& conf_file::integer_end_value_node::operator=(
     return *this;
 }
 
-conf_file::integer_end_value_node& conf_file::integer_end_value_node::operator=(const value_t value)
+libconfigfile::integer_end_value_node& libconfigfile::integer_end_value_node::operator=(const value_t value)
 {
     m_value = value;
 
     return *this;
 }
 
-conf_file::integer_end_value_node::operator value_t() const
+libconfigfile::integer_end_value_node::operator value_t() const
 {
     return m_value;
 }
 
-std::ostream& conf_file::operator<<(std::ostream& out, const integer_end_value_node& i)
+std::ostream& libconfigfile::operator<<(std::ostream& out, const integer_end_value_node& i)
 {
     out << i.m_value;
     return out;
 }
 
-std::istream& conf_file::operator>>(std::istream& in, integer_end_value_node& i)
+std::istream& libconfigfile::operator>>(std::istream& in, integer_end_value_node& i)
 {
     in >> i.m_value;
     return in;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -5,11 +5,11 @@
 #include <cstddef>
 #include <utility>
 
-conf_file::node::~node()
+libconfigfile::node::~node()
 {
 }
 
-conf_file::actual_node_type conf_file::node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::node::get_actual_node_type() const
 {
     return actual_node_type::NODE;
 }

--- a/src/section_node.cpp
+++ b/src/section_node.cpp
@@ -8,113 +8,113 @@
 #include <unordered_map>
 #include <utility>
 
-conf_file::section_node::section_node()
+libconfigfile::section_node::section_node()
     : m_name{},
       m_value{}
 {
 }
 
-conf_file::section_node::section_node(const std::string& name, const value_t& value)
+libconfigfile::section_node::section_node(const std::string& name, const value_t& value)
     : m_name{ name },
       m_value{ value }
 {
 }
 
-conf_file::section_node::section_node(const std::string& name, value_t&& value)
+libconfigfile::section_node::section_node(const std::string& name, value_t&& value)
     : m_name{ name },
       m_value{ std::move(value) }
 {
 }
 
-conf_file::section_node::section_node(std::string&& name, const value_t& value)
+libconfigfile::section_node::section_node(std::string&& name, const value_t& value)
     : m_name{ std::move(name) },
       m_value{ value }
 {
 }
 
-conf_file::section_node::section_node(std::string&& name, value_t&& value)
+libconfigfile::section_node::section_node(std::string&& name, value_t&& value)
     : m_name{ std::move(name) },
       m_value{ std::move(value) }
 {
 }
 
-conf_file::section_node::section_node(const section_node& other)
+libconfigfile::section_node::section_node(const section_node& other)
     : m_name{ other.m_name },
       m_value{ other.m_value }
 {
 }
 
-conf_file::section_node::section_node(section_node&& other)
+libconfigfile::section_node::section_node(section_node&& other)
     : m_name{ std::move(other.m_name) },
       m_value{ std::move(other.m_value) }
 {
 }
 
-conf_file::section_node::~section_node()
+libconfigfile::section_node::~section_node()
 {
 }
 
-conf_file::actual_node_type conf_file::section_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::section_node::get_actual_node_type() const
 {
     return actual_node_type::SECTION_NODE;
 }
 
-conf_file::section_node* conf_file::section_node::create_new() const
+libconfigfile::section_node* libconfigfile::section_node::create_new() const
 {
     return new section_node{};
 }
 
-conf_file::section_node* conf_file::section_node::create_clone() const
+libconfigfile::section_node* libconfigfile::section_node::create_clone() const
 {
     return new section_node{ *this };
 }
 
-conf_file::node_type conf_file::section_node::get_node_type() const
+libconfigfile::node_type libconfigfile::section_node::get_node_type() const
 {
     return node_type::SECTION;
 }
 
-const std::string& conf_file::section_node::get_name() const
+const std::string& libconfigfile::section_node::get_name() const
 {
     return m_name;
 }
 
-std::string& conf_file::section_node::get_name()
+std::string& libconfigfile::section_node::get_name()
 {
     return m_name;
 }
 
-void conf_file::section_node::set_name(const std::string& name)
+void libconfigfile::section_node::set_name(const std::string& name)
 {
     m_name = name;
 }
 
-void conf_file::section_node::set_name(std::string&& name)
+void libconfigfile::section_node::set_name(std::string&& name)
 {
     m_name = std::move(name);
 }
 
-const conf_file::section_node::value_t& conf_file::section_node::get() const
+const libconfigfile::section_node::value_t& libconfigfile::section_node::get() const
 {
     return m_value;
 }
 
-conf_file::section_node::value_t& conf_file::section_node::get()
+libconfigfile::section_node::value_t& libconfigfile::section_node::get()
 {
     return m_value;
 }
 
-void conf_file::section_node::set(const value_t& value)
+void libconfigfile::section_node::set(const value_t& value)
 {
     m_value = value;
 }
 
-void conf_file::section_node::set(value_t&& value)
+void libconfigfile::section_node::set(value_t&& value)
 {
     m_value = std::move(value);
 }
 
-conf_file::section_node& conf_file::section_node::operator=(const section_node& other)
+libconfigfile::section_node& libconfigfile::section_node::operator=(const section_node& other)
 {
     if (this == &other)
     {
@@ -127,7 +127,7 @@ conf_file::section_node& conf_file::section_node::operator=(const section_node& 
     return *this;
 }
 
-conf_file::section_node& conf_file::section_node::operator=(section_node&& other)
+libconfigfile::section_node& libconfigfile::section_node::operator=(section_node&& other)
 {
     if (this == &other)
     {
@@ -140,21 +140,21 @@ conf_file::section_node& conf_file::section_node::operator=(section_node&& other
     return *this;
 }
 
-conf_file::section_node& conf_file::section_node::operator=(const value_t& other)
+libconfigfile::section_node& libconfigfile::section_node::operator=(const value_t& other)
 {
     m_value = other;
 
     return *this;
 }
 
-conf_file::section_node& conf_file::section_node::operator=(value_t&& other)
+libconfigfile::section_node& libconfigfile::section_node::operator=(value_t&& other)
 {
     m_value = std::move(other);
 
     return *this;
 }
 
-conf_file::section_node::operator value_t() const
+libconfigfile::section_node::operator value_t() const
 {
     return m_value;
 }

--- a/src/semantic_error.cpp
+++ b/src/semantic_error.cpp
@@ -5,36 +5,36 @@
 #include <string>
 #include <utility>
 
-conf_file::semantic_error::semantic_error(const std::string& what_arg)
+libconfigfile::semantic_error::semantic_error(const std::string& what_arg)
     : std::runtime_error{ what_arg }
 {
 }
 
-conf_file::semantic_error::semantic_error(const char* what_arg)
+libconfigfile::semantic_error::semantic_error(const char* what_arg)
     : std::runtime_error{ what_arg }
 {
 }
 
-conf_file::semantic_error::semantic_error(const semantic_error& other) noexcept
+libconfigfile::semantic_error::semantic_error(const semantic_error& other) noexcept
     : std::runtime_error{ other }
 {
 }
 
-conf_file::semantic_error::semantic_error(semantic_error&& other) noexcept
+libconfigfile::semantic_error::semantic_error(semantic_error&& other) noexcept
     : std::runtime_error{ std::move(other ) }
 {
 }
 
-conf_file::semantic_error::~semantic_error()
+libconfigfile::semantic_error::~semantic_error()
 {
 }
 
-const char* conf_file::semantic_error::what() const noexcept
+const char* libconfigfile::semantic_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
 
-conf_file::semantic_error& conf_file::semantic_error::operator=(const semantic_error& other) noexcept
+libconfigfile::semantic_error& libconfigfile::semantic_error::operator=(const semantic_error& other) noexcept
 {
     if (this == &other)
     {
@@ -46,7 +46,7 @@ conf_file::semantic_error& conf_file::semantic_error::operator=(const semantic_e
     return *this;
 }
 
-conf_file::semantic_error& conf_file::semantic_error::operator=(semantic_error&& other) noexcept
+libconfigfile::semantic_error& libconfigfile::semantic_error::operator=(semantic_error&& other) noexcept
 {
     if (this == &other)
     {
@@ -58,22 +58,22 @@ conf_file::semantic_error& conf_file::semantic_error::operator=(semantic_error&&
     return *this;
 }
 
-conf_file::semantic_error conf_file::semantic_error::generate_formatted_error(const std::string& file_name, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
+libconfigfile::semantic_error libconfigfile::semantic_error::generate_formatted_error(const std::string& file_name, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
 {
     return semantic_error{ file_name + ":" + std::to_string(pos_line) + ":" + std::to_string(pos_char) + ": " + what_arg };
 }
 
-conf_file::semantic_error conf_file::semantic_error::generate_formatted_error(const file& f, const file_pos& pos, const std::string& what_arg)
+libconfigfile::semantic_error libconfigfile::semantic_error::generate_formatted_error(const file& f, const file_pos& pos, const std::string& what_arg)
 {
     return generate_formatted_error(f.get_file_path(), pos.get_line(), pos.get_char(), what_arg);
 }
 
-conf_file::semantic_error conf_file::semantic_error::generate_formatted_error(const std::string& file_name, const file_pos& pos, const std::string& what_arg)
+libconfigfile::semantic_error libconfigfile::semantic_error::generate_formatted_error(const std::string& file_name, const file_pos& pos, const std::string& what_arg)
 {
     return generate_formatted_error(file_name, pos.get_line(), pos.get_char(), what_arg);
 }
 
-conf_file::semantic_error conf_file::semantic_error::generate_formatted_error(const file& f, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
+libconfigfile::semantic_error libconfigfile::semantic_error::generate_formatted_error(const file& f, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
 {
     return generate_formatted_error(f.get_file_path(), pos_line, pos_char, what_arg);
 }

--- a/src/string_end_value_node.cpp
+++ b/src/string_end_value_node.cpp
@@ -10,76 +10,76 @@
 #include <string>
 #include <utility>
 
-conf_file::string_end_value_node::string_end_value_node()
+libconfigfile::string_end_value_node::string_end_value_node()
     : m_value{}
 {
 }
 
-conf_file::string_end_value_node::string_end_value_node(const value_t& value)
+libconfigfile::string_end_value_node::string_end_value_node(const value_t& value)
     : m_value{ value }
 {
 }
 
-conf_file::string_end_value_node::string_end_value_node(value_t&& value)
+libconfigfile::string_end_value_node::string_end_value_node(value_t&& value)
     : m_value{ std::move(value) }
 {
 }
 
-conf_file::string_end_value_node::string_end_value_node(const string_end_value_node& other)
+libconfigfile::string_end_value_node::string_end_value_node(const string_end_value_node& other)
     : m_value{ other.m_value }
 {
 }
 
-conf_file::string_end_value_node::string_end_value_node(string_end_value_node&& other)
+libconfigfile::string_end_value_node::string_end_value_node(string_end_value_node&& other)
     : m_value{ std::move(other.m_value) }
 {
 }
 
-conf_file::string_end_value_node::~string_end_value_node()
+libconfigfile::string_end_value_node::~string_end_value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::string_end_value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::string_end_value_node::get_actual_node_type() const
 {
     return actual_node_type::STRING_END_VALUE_NODE;
 }
 
-conf_file::string_end_value_node* conf_file::string_end_value_node::create_new() const
+libconfigfile::string_end_value_node* libconfigfile::string_end_value_node::create_new() const
 {
     return new string_end_value_node{};
 }
 
-conf_file::string_end_value_node* conf_file::string_end_value_node::create_clone() const
+libconfigfile::string_end_value_node* libconfigfile::string_end_value_node::create_clone() const
 {
     return new string_end_value_node{ *this };
 }
 
-conf_file::end_value_node_type conf_file::string_end_value_node::get_end_value_node_type() const
+libconfigfile::end_value_node_type libconfigfile::string_end_value_node::get_end_value_node_type() const
 {
     return end_value_node_type::STRING;
 }
 
-const conf_file::string_end_value_node::value_t& conf_file::string_end_value_node::get() const
+const libconfigfile::string_end_value_node::value_t& libconfigfile::string_end_value_node::get() const
 {
     return m_value;
 }
 
-conf_file::string_end_value_node::value_t& conf_file::string_end_value_node::get()
+libconfigfile::string_end_value_node::value_t& libconfigfile::string_end_value_node::get()
 {
     return m_value;
 }
 
-void conf_file::string_end_value_node::set(const value_t& value)
+void libconfigfile::string_end_value_node::set(const value_t& value)
 {
     m_value = value;
 }
 
-void conf_file::string_end_value_node::set(value_t&& value)
+void libconfigfile::string_end_value_node::set(value_t&& value)
 {
     m_value = std::move(value);
 }
 
-conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(const string_end_value_node& other)
+libconfigfile::string_end_value_node& libconfigfile::string_end_value_node::operator=(const string_end_value_node& other)
 {
     if (this == &other)
     {
@@ -91,7 +91,7 @@ conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(co
     return *this;
 }
 
-conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(string_end_value_node&& other)
+libconfigfile::string_end_value_node& libconfigfile::string_end_value_node::operator=(string_end_value_node&& other)
 {
     if (this == &other)
     {
@@ -103,32 +103,32 @@ conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(st
     return *this;
 }
 
-conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(const value_t& value)
+libconfigfile::string_end_value_node& libconfigfile::string_end_value_node::operator=(const value_t& value)
 {
     m_value = value;
 
     return *this;
 }
 
-conf_file::string_end_value_node& conf_file::string_end_value_node::operator=(value_t&& value)
+libconfigfile::string_end_value_node& libconfigfile::string_end_value_node::operator=(value_t&& value)
 {
     m_value = std::move(value);
 
     return *this;
 }
 
-conf_file::string_end_value_node::operator value_t() const
+libconfigfile::string_end_value_node::operator value_t() const
 {
     return m_value;
 }
 
-std::ostream& conf_file::operator<<(std::ostream& out, const string_end_value_node& s)
+std::ostream& libconfigfile::operator<<(std::ostream& out, const string_end_value_node& s)
 {
     out << s.m_value;
     return out;
 }
 
-std::istream& conf_file::operator>>(std::istream& in, string_end_value_node& s)
+std::istream& libconfigfile::operator>>(std::istream& in, string_end_value_node& s)
 {
     in >> s.m_value;
     return in;

--- a/src/syntax_error.cpp
+++ b/src/syntax_error.cpp
@@ -5,36 +5,36 @@
 #include <string>
 #include <utility>
 
-conf_file::syntax_error::syntax_error(const std::string& what_arg)
+libconfigfile::syntax_error::syntax_error(const std::string& what_arg)
     : std::runtime_error{ what_arg }
 {
 }
 
-conf_file::syntax_error::syntax_error(const char* what_arg)
+libconfigfile::syntax_error::syntax_error(const char* what_arg)
     : std::runtime_error{ what_arg }
 {
 }
 
-conf_file::syntax_error::syntax_error(const syntax_error& other) noexcept
+libconfigfile::syntax_error::syntax_error(const syntax_error& other) noexcept
     : std::runtime_error{ other }
 {
 }
 
-conf_file::syntax_error::syntax_error(syntax_error&& other) noexcept
+libconfigfile::syntax_error::syntax_error(syntax_error&& other) noexcept
     : std::runtime_error{ std::move(other ) }
 {
 }
 
-conf_file::syntax_error::~syntax_error()
+libconfigfile::syntax_error::~syntax_error()
 {
 }
 
-const char* conf_file::syntax_error::what() const noexcept
+const char* libconfigfile::syntax_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
 
-conf_file::syntax_error& conf_file::syntax_error::operator=(const syntax_error& other) noexcept
+libconfigfile::syntax_error& libconfigfile::syntax_error::operator=(const syntax_error& other) noexcept
 {
     if (this == &other)
     {
@@ -46,7 +46,7 @@ conf_file::syntax_error& conf_file::syntax_error::operator=(const syntax_error& 
     return *this;
 }
 
-conf_file::syntax_error& conf_file::syntax_error::operator=(syntax_error&& other) noexcept
+libconfigfile::syntax_error& libconfigfile::syntax_error::operator=(syntax_error&& other) noexcept
 {
     if (this == &other)
     {
@@ -58,22 +58,22 @@ conf_file::syntax_error& conf_file::syntax_error::operator=(syntax_error&& other
     return *this;
 }
 
-conf_file::syntax_error conf_file::syntax_error::generate_formatted_error(const std::string& file_name, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
+libconfigfile::syntax_error libconfigfile::syntax_error::generate_formatted_error(const std::string& file_name, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
 {
     return syntax_error{ file_name + ":" + std::to_string(pos_line) + ":" + std::to_string(pos_char) + ": " + what_arg };
 }
 
-conf_file::syntax_error conf_file::syntax_error::generate_formatted_error(const file& f, const file_pos& pos, const std::string& what_arg)
+libconfigfile::syntax_error libconfigfile::syntax_error::generate_formatted_error(const file& f, const file_pos& pos, const std::string& what_arg)
 {
     return generate_formatted_error(f.get_file_path(), pos.get_line(), pos.get_char(), what_arg);
 }
 
-conf_file::syntax_error conf_file::syntax_error::generate_formatted_error(const std::string& file_name, const file_pos& pos, const std::string& what_arg)
+libconfigfile::syntax_error libconfigfile::syntax_error::generate_formatted_error(const std::string& file_name, const file_pos& pos, const std::string& what_arg)
 {
     return generate_formatted_error(file_name, pos.get_line(), pos.get_char(), what_arg);
 }
 
-conf_file::syntax_error conf_file::syntax_error::generate_formatted_error(const file& f, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
+libconfigfile::syntax_error libconfigfile::syntax_error::generate_formatted_error(const file& f, const size_t pos_line, const size_t pos_char, const std::string& what_arg)
 {
     return generate_formatted_error(f.get_file_path(), pos_line, pos_char, what_arg);
 }

--- a/src/value_node.cpp
+++ b/src/value_node.cpp
@@ -6,16 +6,16 @@
 #include <cstddef>
 #include <utility>
 
-conf_file::value_node::~value_node()
+libconfigfile::value_node::~value_node()
 {
 }
 
-conf_file::actual_node_type conf_file::value_node::get_actual_node_type() const
+libconfigfile::actual_node_type libconfigfile::value_node::get_actual_node_type() const
 {
     return actual_node_type::VALUE_NODE;
 }
 
-conf_file::node_type conf_file::value_node::get_node_type() const
+libconfigfile::node_type libconfigfile::value_node::get_node_type() const
 {
     return node_type::VALUE;
 }


### PR DESCRIPTION
The top-level namespace for this project was originally `conf_file`, as I had yet to decide on a name for it. Now that that has been done, the top-level namespace has been changed to `libconfigfile`.