### PR TITLE
Improve section_node class 

### DIFF
--- a/include/key.hpp
+++ b/include/key.hpp
@@ -1,0 +1,11 @@
+#ifndef LIBCONFIGFILE_KEY_HPP
+#define LIBCONFIGFILE_KEY_HPP
+
+#include <string>
+
+namespace libconfigfile
+{
+    using key = std::string;
+}
+
+#endif

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -218,11 +218,28 @@ namespace libconfigfile
             void rehash(size_type count);
             void reserve(size_type count);
 
+            hasher hash_function() const;
+            key_equal key_eq() const;
+
         public:
 
             section_node& operator=(const section_node& other);
             section_node& operator=(section_node&& other);
+
+        public:
+
+            friend void swap(section_node& lhs, section_node& rhs);
+            template<typename Pred>
+                friend size_type erase_if(section_node& c, Pred pred);
     };
+
+    void swap(section_node& lhs, section_node& rhs);
+    template<typename Pred>
+        section_node::size_type erase_if(section_node& c, Pred pred)
+        {
+            using std::erase_if;
+            return erase_if(c.m_contents, pred);
+        }
 }
 
 #endif

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -1,13 +1,17 @@
 #ifndef LIBCONFIGFILE_SECTION_NODE_HPP
 #define LIBCONFIGFILE_SECTION_NODE_HPP
 
+#include "key.hpp"
 #include "node.hpp"
 #include "node_ptr.hpp"
 #include "node_types.hpp"
 
 #include <cstddef>
+#include <initializer_list>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
 
 namespace libconfigfile
 {
@@ -15,20 +19,33 @@ namespace libconfigfile
     {
         public:
 
-            using value_t = std::unordered_map<std::string, node_ptr<node>>;
+            using map_t = std::unordered_map<key, node_ptr<node>>;
+            using key_type = map_t::key_type;
+            using mapped_type = map_t::mapped_type;
+            using value_type = map_t::value_type;
+            using size_type = map_t::size_type;
+            using difference_type = map_t::difference_type;
+            using hasher = map_t::hasher;
+            using key_equal = map_t::key_equal;
+            using allocator_type = map_t::allocator_type;
+            using reference = map_t::reference;
+            using const_reference = map_t::const_reference;
+            using pointer = map_t::pointer;
+            using const_pointer = map_t::const_pointer;
+            using iterator = map_t::iterator;
+            using const_iterator = map_t::const_iterator;
+            using local_iterator = map_t::local_iterator;
+            using const_local_iterator = map_t::const_local_iterator;
+            using map_node_type = map_t::node_type;
+            using insert_return_type = map_t::insert_return_type;
 
         private:
 
-            std::string m_name;
-            value_t m_value;
+            map_t m_contents;
 
         public:
 
             section_node();
-            explicit section_node(const std::string& name, const value_t& value);
-            explicit section_node(const std::string& name, value_t&& value);
-            explicit section_node(std::string&& name, const value_t& value);
-            explicit section_node(std::string&& name, value_t&& value);
             section_node(const section_node& other);
             section_node(section_node&& other);
 
@@ -40,25 +57,116 @@ namespace libconfigfile
 
             virtual section_node* create_new() const override;
             virtual section_node* create_clone() const override;
-            virtual node_type get_node_type() const override final;
+            virtual libconfigfile::node_type get_node_type() const override final;
 
-            const std::string& get_name() const;
-            std::string& get_name();
-            void set_name(const std::string& name);
-            void set_name(std::string&& name);
-            const value_t& get() const;
-            value_t& get();
-            void set(const value_t& value);
-            void set(value_t&& value);
+            iterator begin();
+            const_iterator begin() const;
+            const_iterator cbegin() const;
+            iterator end();
+            const_iterator end() const;
+            const_iterator cend() const;
+
+            bool empty() const;
+            size_type size() const;
+            size_type max_size() const;
+
+            void clear();
+            std::pair<iterator,bool> insert(const value_type& value);
+            std::pair<iterator,bool> insert(value_type&& value);
+            template<typename P>
+                std::enable_if<std::is_constructible<value_type, P&&>::value, std::pair<iterator,bool>>
+                insert(P&& value)
+                {
+                    return m_contents.insert(std::move(value));
+                }
+            iterator insert(const_iterator hint, const value_type& value);
+            iterator insert(const_iterator hint, value_type&& value);
+            template<typename P>
+                std::enable_if<std::is_constructible<value_type, P&&>::value, iterator>
+                insert(const_iterator hint, P&& value)
+                {
+                    return m_contents.insert(hint, std::move(value));
+                }
+            template<typename InputIt>
+                void insert(InputIt first, InputIt last)
+                {
+                    m_contents.insert(first, last);
+                }
+            void insert(std::initializer_list<value_type> ilist);
+            insert_return_type insert(map_node_type&& nh);
+            iterator insert(const_iterator hint, map_node_type&& nh);
+            template<typename M>
+                std::pair<iterator,bool> insert_or_assign(const key_type& k, M&& obj)
+                {
+                    return m_contents.insert_or_assign(k, std::move(obj));
+                }
+            template<typename M>
+                std::pair<iterator,bool> insert_or_assign(key_type&& k, M&& obj)
+                {
+                    return m_contents.insert_or_assign(std::move(k), std::move(obj));
+                }
+            template<typename M>
+                iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj)
+                {
+                    return m_contents.insert_or_assign(hint, k, std::move(obj));
+                }
+            template<typename M>
+                iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj)
+                {
+                    return m_contents.insert_or_assign(hint, std::move(k), std::move(obj));
+                }
+            template<typename... Args>
+                std::pair<iterator,bool> emplace(Args&&... args)
+                {
+                    return m_contents.emplace(std::move(args...));
+                }
+            template<typename... Args>
+                iterator emplace_hint(const_iterator hint, Args&&... args)
+                {
+                    return m_contents.emplace(hint, std::move(args...));
+                }
+            template<typename... Args>
+                std::pair<iterator,bool> try_emplace(const key_type& k, Args&&... args)
+                {
+                    return m_contents.try_emplace(k, std::move(args...));
+                }
+            template<typename... Args>
+                std::pair<iterator,bool> try_emplace(key_type&& k, Args&&... args)
+                {
+                    return m_contents.try_emplace(std::move(k), std::move(args...));
+                }
+            template<typename... Args>
+                iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args)
+                {
+                    return m_contents.try_emplace(hint, k, std::move(args...));
+                }
+            template<typename... Args>
+                iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args)
+                {
+                    return m_contents.try_emplace(hint, std::move(k), std::move(args...));
+                }
+            iterator erase(const_iterator pos);
+            iterator erase(const_iterator first, const_iterator last);
+            size_type erase(const key_type& k);
+            void swap(section_node& other);
+            map_node_type extract(const_iterator position);
+            map_node_type extract(const key_type& k);
+            void merge(section_node& source);
+            void merge(section_node&& source);
+
+            mapped_type& at(const key_type& key);
+            const mapped_type& at(const key_type& key) const;
+            mapped_type& operator[](const key_type& key);
+            mapped_type& operator[](key_type&& key);
+            size_type count(const key_type& key) const;
+            iterator find(const key_type& key);
+            const_iterator find(const key_type& key) const;
+            bool contains(const key& key) const;
 
         public:
 
             section_node& operator=(const section_node& other);
             section_node& operator=(section_node&& other);
-            section_node& operator=(const value_t& value);
-            section_node& operator=(value_t&& value);
-
-            explicit operator value_t() const;
     };
 }
 

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -159,9 +159,64 @@ namespace libconfigfile
             mapped_type& operator[](const key_type& key);
             mapped_type& operator[](key_type&& key);
             size_type count(const key_type& key) const;
+            template<typename K>
+                auto count(const K& x) const
+                -> decltype(m_contents.count(x))
+                {
+                    return m_contents.count(x);
+                }
             iterator find(const key_type& key);
             const_iterator find(const key_type& key) const;
+            template<typename K>
+                auto find(const K& x)
+                -> decltype(m_contents.find(x))
+                {
+                    return m_contents.find(x);
+                }
+            template<typename K>
+                auto find(const K& x) const
+                -> decltype(m_contents.find(x))
+                {
+                    return m_contents.find(x);
+                }
             bool contains(const key& key) const;
+            template<typename K>
+                auto contains(const K& x) const
+                -> decltype(m_contents.contains(x))
+                {
+                    return m_contents.contains(x);
+                }
+            std::pair<iterator,iterator> equal_range(const key_type& key);
+            std::pair<const_iterator,const_iterator> equal_range(const key_type& key) const;
+            template<typename K>
+                auto equal_range(const K& x)
+                -> decltype(m_contents.equal_range(x))
+                {
+                    return m_contents.equal_range(x);
+                }
+            template<typename K>
+                auto equal_range(const K& x) const
+                -> decltype(m_contents.equal_range(x))
+                {
+                    return m_contents.equal_range(x);
+                }
+
+            local_iterator begin(size_type n);
+            const_local_iterator begin(size_type n) const;
+            const_local_iterator cbegin(size_type n) const;
+            local_iterator end(size_type n);
+            const_local_iterator end(size_type n) const;
+            const_local_iterator cend(size_type n) const;
+            size_type bucket_count() const;
+            size_type max_bucket_count() const;
+            size_type bucket_size(size_type n) const;
+            size_type bucket(const key_type& key) const;
+
+            float load_factor() const;
+            float max_load_factor() const;
+            void max_load_factor(float ml);
+            void rehash(size_type count);
+            void reserve(size_type count);
 
         public:
 

--- a/src/section_node.cpp
+++ b/src/section_node.cpp
@@ -207,6 +207,91 @@ libconfigfile::section_node::const_iterator libconfigfile::section_node::find(co
     return m_contents.find(key);
 }
 
+std::pair<libconfigfile::section_node::iterator,libconfigfile::section_node::iterator> libconfigfile::section_node::equal_range(const key_type& key)
+{
+    return m_contents.equal_range(key);
+}
+
+std::pair<libconfigfile::section_node::const_iterator,libconfigfile::section_node::const_iterator> libconfigfile::section_node::equal_range(const key_type& key) const
+{
+    return m_contents.equal_range(key);
+}
+
+libconfigfile::section_node::local_iterator libconfigfile::section_node::begin(size_type n)
+{
+    return m_contents.begin(n);
+}
+
+libconfigfile::section_node::const_local_iterator libconfigfile::section_node::begin(size_type n) const
+{
+    return m_contents.begin(n);
+}
+
+libconfigfile::section_node::const_local_iterator libconfigfile::section_node::cbegin(size_type n) const
+{
+    return m_contents.cbegin(n);
+}
+
+libconfigfile::section_node::local_iterator libconfigfile::section_node::end(size_type n)
+{
+    return m_contents.end(n);
+}
+
+libconfigfile::section_node::const_local_iterator libconfigfile::section_node::end(size_type n) const
+{
+    return m_contents.end(n);
+}
+
+libconfigfile::section_node::const_local_iterator libconfigfile::section_node::cend(size_type n) const
+{
+    return m_contents.cend(n);
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::bucket_count() const
+{
+    return m_contents.bucket_count();
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::max_bucket_count() const
+{
+    return m_contents.max_bucket_count();
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::bucket_size(size_type n) const
+{
+    return m_contents.bucket_size(n);
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::bucket(const key_type& key) const
+{
+    return m_contents.bucket(key);
+}
+
+float libconfigfile::section_node::load_factor() const
+{
+    return m_contents.load_factor();
+}
+
+float libconfigfile::section_node::max_load_factor() const
+{
+    return m_contents.max_load_factor();
+}
+
+void libconfigfile::section_node::max_load_factor(float ml)
+{
+    m_contents.max_load_factor(ml);
+}
+
+void libconfigfile::section_node::rehash(size_type count)
+{
+    m_contents.rehash(count);
+}
+
+void libconfigfile::section_node::reserve(size_type count)
+{
+    m_contents.reserve(count);
+}
+
 libconfigfile::section_node& libconfigfile::section_node::operator=(const section_node& other)
 {
     if (this == &other)

--- a/src/section_node.cpp
+++ b/src/section_node.cpp
@@ -3,9 +3,7 @@
 #include "node.hpp"
 #include "node_types.hpp"
 
-#include <cstddef>
 #include <initializer_list>
-#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -292,6 +290,16 @@ void libconfigfile::section_node::reserve(size_type count)
     m_contents.reserve(count);
 }
 
+libconfigfile::section_node::hasher libconfigfile::section_node::hash_function() const
+{
+    return m_contents.hash_function();
+}
+
+libconfigfile::section_node::key_equal libconfigfile::section_node::key_eq() const
+{
+    return m_contents.key_eq();
+}
+
 libconfigfile::section_node& libconfigfile::section_node::operator=(const section_node& other)
 {
     if (this == &other)
@@ -314,4 +322,10 @@ libconfigfile::section_node& libconfigfile::section_node::operator=(section_node
     m_contents = std::move(other.m_contents);
 
     return *this;
+}
+
+void libconfigfile::swap(section_node& lhs, section_node& rhs)
+{
+    using std::swap;
+    swap(lhs.m_contents, rhs.m_contents);
 }

--- a/src/section_node.cpp
+++ b/src/section_node.cpp
@@ -4,49 +4,22 @@
 #include "node_types.hpp"
 
 #include <cstddef>
+#include <initializer_list>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
 libconfigfile::section_node::section_node()
-    : m_name{},
-      m_value{}
-{
-}
-
-libconfigfile::section_node::section_node(const std::string& name, const value_t& value)
-    : m_name{ name },
-      m_value{ value }
-{
-}
-
-libconfigfile::section_node::section_node(const std::string& name, value_t&& value)
-    : m_name{ name },
-      m_value{ std::move(value) }
-{
-}
-
-libconfigfile::section_node::section_node(std::string&& name, const value_t& value)
-    : m_name{ std::move(name) },
-      m_value{ value }
-{
-}
-
-libconfigfile::section_node::section_node(std::string&& name, value_t&& value)
-    : m_name{ std::move(name) },
-      m_value{ std::move(value) }
 {
 }
 
 libconfigfile::section_node::section_node(const section_node& other)
-    : m_name{ other.m_name },
-      m_value{ other.m_value }
+    : m_contents{ other.m_contents }
 {
 }
 
 libconfigfile::section_node::section_node(section_node&& other)
-    : m_name{ std::move(other.m_name) },
-      m_value{ std::move(other.m_value) }
+    : m_contents{ std::move(other.m_contents) }
 {
 }
 
@@ -71,47 +44,167 @@ libconfigfile::section_node* libconfigfile::section_node::create_clone() const
 
 libconfigfile::node_type libconfigfile::section_node::get_node_type() const
 {
-    return node_type::SECTION;
+    return libconfigfile::node_type::SECTION;
 }
 
-const std::string& libconfigfile::section_node::get_name() const
+libconfigfile::section_node::iterator libconfigfile::section_node::begin()
 {
-    return m_name;
+    return m_contents.begin();
 }
 
-std::string& libconfigfile::section_node::get_name()
+libconfigfile::section_node::const_iterator libconfigfile::section_node::begin() const
 {
-    return m_name;
+    return m_contents.begin();
 }
 
-void libconfigfile::section_node::set_name(const std::string& name)
+libconfigfile::section_node::const_iterator libconfigfile::section_node::cbegin() const
 {
-    m_name = name;
+    return m_contents.cbegin();
 }
 
-void libconfigfile::section_node::set_name(std::string&& name)
+libconfigfile::section_node::iterator libconfigfile::section_node::end()
 {
-    m_name = std::move(name);
+    return m_contents.end();
 }
 
-const libconfigfile::section_node::value_t& libconfigfile::section_node::get() const
+libconfigfile::section_node::const_iterator libconfigfile::section_node::end() const
 {
-    return m_value;
+    return m_contents.end();
 }
 
-libconfigfile::section_node::value_t& libconfigfile::section_node::get()
+libconfigfile::section_node::const_iterator libconfigfile::section_node::cend() const
 {
-    return m_value;
+    return m_contents.cend();
 }
 
-void libconfigfile::section_node::set(const value_t& value)
+bool libconfigfile::section_node::empty() const
 {
-    m_value = value;
+    return m_contents.empty();
 }
 
-void libconfigfile::section_node::set(value_t&& value)
+libconfigfile::section_node::size_type libconfigfile::section_node::size() const
 {
-    m_value = std::move(value);
+    return m_contents.size();
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::max_size() const
+{
+    return m_contents.max_size();
+}
+
+void libconfigfile::section_node::clear()
+{
+    m_contents.clear();
+}
+
+std::pair<libconfigfile::section_node::iterator,bool> libconfigfile::section_node::insert(const value_type& value)
+{
+    return m_contents.insert(value);
+}
+
+std::pair<libconfigfile::section_node::iterator,bool> libconfigfile::section_node::insert(value_type&& value)
+{
+    return m_contents.insert(std::move(value));
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::insert(const_iterator hint, const value_type& value)
+{
+    return m_contents.insert(hint, value);
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::insert(const_iterator hint, value_type&& value)
+{
+    return m_contents.insert(hint, std::move(value));
+}
+
+void libconfigfile::section_node::insert(std::initializer_list<value_type> ilist)
+{
+    m_contents.insert(ilist);
+}
+
+libconfigfile::section_node::insert_return_type libconfigfile::section_node::insert(map_node_type&& nh)
+{
+    return m_contents.insert(std::move(nh));
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::insert(const_iterator hint, map_node_type&& nh)
+{
+    return m_contents.insert(hint, std::move(nh));
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::erase(const_iterator pos)
+{
+    return m_contents.erase(pos);
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::erase(const_iterator first, const_iterator last)
+{
+    return m_contents.erase(first, last);
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::erase(const key_type& k)
+{
+    return m_contents.erase(k);
+}
+
+void libconfigfile::section_node::swap(section_node& other)
+{
+    m_contents.swap(other.m_contents);
+}
+
+libconfigfile::section_node::map_node_type libconfigfile::section_node::extract(const_iterator position)
+{
+    return m_contents.extract(position);
+}
+
+libconfigfile::section_node::map_node_type libconfigfile::section_node::extract(const key_type& k)
+{
+    return m_contents.extract(k);
+}
+
+void libconfigfile::section_node::merge(section_node& other)
+{
+    m_contents.merge(other.m_contents);
+}
+
+void libconfigfile::section_node::merge(section_node&& other)
+{
+    m_contents.merge(std::move(other.m_contents));
+}
+
+libconfigfile::section_node::mapped_type& libconfigfile::section_node::at(const key_type& key)
+{
+    return m_contents.at(key);
+}
+
+const libconfigfile::section_node::mapped_type& libconfigfile::section_node::at(const key_type& key) const
+{
+    return m_contents.at(key);
+}
+
+libconfigfile::section_node::mapped_type& libconfigfile::section_node::operator[](const key_type& key)
+{
+    return m_contents[key];
+}
+
+libconfigfile::section_node::mapped_type& libconfigfile::section_node::operator[](key_type&& key)
+{
+    return m_contents[std::move(key)];
+}
+
+libconfigfile::section_node::size_type libconfigfile::section_node::count(const key_type& key) const
+{
+    return m_contents.count(key);
+}
+
+libconfigfile::section_node::iterator libconfigfile::section_node::find(const key_type& key)
+{
+    return m_contents.find(key);
+}
+
+libconfigfile::section_node::const_iterator libconfigfile::section_node::find(const key_type& key) const
+{
+    return m_contents.find(key);
 }
 
 libconfigfile::section_node& libconfigfile::section_node::operator=(const section_node& other)
@@ -121,8 +214,7 @@ libconfigfile::section_node& libconfigfile::section_node::operator=(const sectio
         return *this;
     }
 
-    m_name = other.m_name;
-    m_value = other.m_value;
+    m_contents = other.m_contents;
 
     return *this;
 }
@@ -134,27 +226,7 @@ libconfigfile::section_node& libconfigfile::section_node::operator=(section_node
         return *this;
     }
 
-    m_name = std::move(other.m_name);
-    m_value = std::move(other.m_value);
+    m_contents = std::move(other.m_contents);
 
     return *this;
-}
-
-libconfigfile::section_node& libconfigfile::section_node::operator=(const value_t& other)
-{
-    m_value = other;
-
-    return *this;
-}
-
-libconfigfile::section_node& libconfigfile::section_node::operator=(value_t&& other)
-{
-    m_value = std::move(other);
-
-    return *this;
-}
-
-libconfigfile::section_node::operator value_t() const
-{
-    return m_value;
 }


### PR DESCRIPTION
Replaces get()/set() for `std::unordered_map` member variable in `section_node` class with a set of member functions to properly mimic the functionality of `std::unordered_map`.