### PR TITLE
Improve `array_value_node` interface

### DIFF
--- a/include/array_value_node.hpp
+++ b/include/array_value_node.hpp
@@ -29,16 +29,14 @@ public:
   using const_reverse_iterator = vector_t::const_reverse_iterator;
 
 private:
-  value_t m_value;
+  vector_t m_contents;
 
 public:
   array_value_node();
-  explicit array_value_node(const value_t &value);
-  explicit array_value_node(value_t &&value);
   array_value_node(const array_value_node &other);
   array_value_node(array_value_node &&other);
 
-  virtual ~array_value_node();
+  virtual ~array_value_node() override;
 
 public:
   virtual actual_node_type get_actual_node_type() const override;
@@ -47,19 +45,93 @@ public:
   virtual array_value_node *create_clone() const override;
   virtual value_node_type get_value_node_type() const override final;
 
-  const value_t &get() const;
-  value_t &get();
-  void set(const value_t &value);
-  void set(value_t &&value);
+  reference at(size_type pos);
+  const_reference at(size_type pos) const;
+  reference operator[](size_type pos);
+  const_reference operator[](size_type pos) const;
+  reference front();
+  const_reference front() const;
+  reference back();
+  const_reference back() const;
+  value_type *data();
+  const value_type *data() const;
+
+  iterator begin();
+  const_iterator begin() const;
+  const_iterator cbegin() const;
+  iterator end();
+  const_iterator end() const;
+  const_iterator cend() const;
+  reverse_iterator rbegin();
+  const_reverse_iterator rbegin() const;
+  const_reverse_iterator crbegin() const;
+  reverse_iterator rend();
+  const_reverse_iterator rend() const;
+  const_reverse_iterator crend() const;
+
+  bool empty() const;
+  size_type size() const;
+  size_type max_size() const;
+  void reserve(size_type new_cap);
+  size_type capacity() const;
+  void shrink_to_fit();
+
+  void clear();
+  iterator insert(const_iterator pos, const value_type &value);
+  iterator insert(const_iterator pos, value_type &&value);
+  iterator insert(const_iterator pos, size_type count, const value_type &value);
+  template <typename InputIt>
+  iterator insert(const_iterator pos, InputIt first, InputIt last) {
+    return m_contents.insert(pos, first, last);
+  }
+  iterator insert(const_iterator pos, std::initializer_list<value_type> ilist);
+  template <typename... Args>
+  iterator emplace(const_iterator pos, Args &&...args) {
+    return m_contents.emplace(pos, std::move(args...));
+  }
+  iterator erase(const_iterator pos);
+  iterator erase(const_iterator first, const_iterator last);
+  void push_back(const value_type &value);
+  void push_back(value_type &&value);
+  template <typename... Args> reference emplace_back(Args &&...args) {
+    return m_contents.emplace_back(std::move(args...));
+  }
+  void pop_back();
+  void resize(size_type count);
+  void resize(size_type count, const value_type &value);
+  void swap(array_value_node &other);
 
 public:
   array_value_node &operator=(const array_value_node &other);
   array_value_node &operator=(array_value_node &&other);
-  array_value_node &operator=(const value_t &value);
-  array_value_node &operator=(value_t &&value);
 
-  explicit operator value_t() const;
+public:
+  friend bool operator==(const array_value_node &lhs,
+                         const array_value_node &rhs);
+  friend auto operator<=>(const array_value_node &lhs,
+                          const array_value_node &rhs)
+      -> decltype(lhs.m_contents <=> rhs.m_contents);
+  friend void swap(array_value_node &lhs, array_value_node &rhs);
+  template <typename U>
+  friend array_value_node::size_type erase(array_value_node &c, const U &value);
+  template <typename Pred>
+  friend array_value_node::size_type erase_if(array_value_node &c, Pred pred);
 };
+
+bool operator==(const array_value_node &lhs, const array_value_node &rhs);
+auto operator<=>(const array_value_node &lhs, const array_value_node &rhs)
+    -> decltype(lhs.m_contents <=> rhs.m_contents);
+void swap(array_value_node &lhs, array_value_node &rhs);
+template <typename U>
+array_value_node::size_type erase(array_value_node &c, const U &value) {
+  using std::erase;
+  return erase(c.m_contents, value);
+}
+template <typename Pred>
+array_value_node::size_type erase_if(array_value_node &c, Pred pred) {
+  using std::erase_if;
+  return erase_if(c, pred);
+}
 } // namespace libconfigfile
 
 #endif

--- a/include/array_value_node.hpp
+++ b/include/array_value_node.hpp
@@ -6,13 +6,27 @@
 #include "node_types.hpp"
 #include "value_node.hpp"
 
-#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace libconfigfile {
 class array_value_node : public value_node {
 public:
-  using value_t = std::vector<node_ptr<value_node>>;
+  using vector_t = std::vector<node_ptr<value_node>>;
+  using value_type = vector_t::value_type;
+  using allocator_type = vector_t::allocator_type;
+  using size_type = vector_t::size_type;
+  using difference_type = vector_t::difference_type;
+  using reference = vector_t::reference;
+  using const_reference = vector_t::const_reference;
+  using pointer = vector_t::pointer;
+  using const_pointer = vector_t::const_pointer;
+  using iterator = vector_t::iterator;
+  using const_iterator = vector_t::const_iterator;
+  using reverse_iterator = vector_t::reverse_iterator;
+  using const_reverse_iterator = vector_t::const_reverse_iterator;
 
 private:
   value_t m_value;

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -14,28 +14,28 @@
 namespace libconfigfile {
 class section_node : public node {
 public:
-  using map_t = std::unordered_map<key, node_ptr<node>>;
-  using key_type = map_t::key_type;
-  using mapped_type = map_t::mapped_type;
-  using value_type = map_t::value_type;
-  using size_type = map_t::size_type;
-  using difference_type = map_t::difference_type;
-  using hasher = map_t::hasher;
-  using key_equal = map_t::key_equal;
-  using allocator_type = map_t::allocator_type;
-  using reference = map_t::reference;
-  using const_reference = map_t::const_reference;
-  using pointer = map_t::pointer;
-  using const_pointer = map_t::const_pointer;
-  using iterator = map_t::iterator;
-  using const_iterator = map_t::const_iterator;
-  using local_iterator = map_t::local_iterator;
-  using const_local_iterator = map_t::const_local_iterator;
-  using map_node_type = map_t::node_type;
-  using insert_return_type = map_t::insert_return_type;
+  using unordered_map_t = std::unordered_map<key, node_ptr<node>>;
+  using key_type = unordered_map_t::key_type;
+  using mapped_type = unordered_map_t::mapped_type;
+  using value_type = unordered_map_t::value_type;
+  using size_type = unordered_map_t::size_type;
+  using difference_type = unordered_map_t::difference_type;
+  using hasher = unordered_map_t::hasher;
+  using key_equal = unordered_map_t::key_equal;
+  using allocator_type = unordered_map_t::allocator_type;
+  using reference = unordered_map_t::reference;
+  using const_reference = unordered_map_t::const_reference;
+  using pointer = unordered_map_t::pointer;
+  using const_pointer = unordered_map_t::const_pointer;
+  using iterator = unordered_map_t::iterator;
+  using const_iterator = unordered_map_t::const_iterator;
+  using local_iterator = unordered_map_t::local_iterator;
+  using const_local_iterator = unordered_map_t::const_local_iterator;
+  using map_node_type = unordered_map_t::node_type;
+  using insert_return_type = unordered_map_t::insert_return_type;
 
 private:
-  map_t m_contents;
+  unordered_map_t m_contents;
 
 public:
   section_node();

--- a/src/array_value_node.cpp
+++ b/src/array_value_node.cpp
@@ -5,22 +5,29 @@
 #include "value_node.hpp"
 
 #include <initializer_list>
+#include <memory>
 #include <utility>
 #include <vector>
 
-libconfigfile::array_value_node::array_value_node() : m_value{} {}
+libconfigfile::array_value_node::array_value_node() : m_contents{} {}
 
-libconfigfile::array_value_node::array_value_node(const value_t &value)
-    : m_value{value} {}
+libconfigfile::array_value_node::array_value_node(size_type count)
+    : m_contents{count} {}
 
-libconfigfile::array_value_node::array_value_node(value_t &&value)
-    : m_value{std::move(value)} {}
+libconfigfile::array_value_node::array_value_node(size_type count,
+                                                  const value_type &value)
+    : m_contents{count, value} {}
+
+libconfigfile::array_value_node::array_value_node(
+    std::initializer_list<value_type> init)
+    : m_contents{init} {}
 
 libconfigfile::array_value_node::array_value_node(const array_value_node &other)
-    : m_value{other.m_value} {}
+    : m_contents{other.m_contents} {}
 
-libconfigfile::array_value_node::array_value_node(array_value_node &&other)
-    : m_value{std::move(other.m_value)} {}
+libconfigfile::array_value_node::array_value_node(
+    array_value_node &&other) noexcept
+    : m_contents{std::move(other.m_contents)} {}
 
 libconfigfile::array_value_node::~array_value_node() {}
 
@@ -44,22 +51,216 @@ libconfigfile::array_value_node::get_value_node_type() const {
   return value_node_type::ARRAY;
 }
 
-const libconfigfile::array_value_node::value_t &
-libconfigfile::array_value_node::get() const {
-  return m_value;
+void libconfigfile::array_value_node::assign(size_type count,
+                                             const value_type &value) {
+  m_contents.assign(count, value);
 }
 
-libconfigfile::array_value_node::value_t &
-libconfigfile::array_value_node::get() {
-  return m_value;
+void libconfigfile::array_value_node::assign(
+    std::initializer_list<value_type> ilist) {
+  m_contents.assign(ilist);
 }
 
-void libconfigfile::array_value_node::set(const value_t &value) {
-  m_value = value;
+libconfigfile::array_value_node::allocator_type
+libconfigfile::array_value_node::get_allocator() const {
+  return m_contents.get_allocator();
 }
 
-void libconfigfile::array_value_node::set(value_t &&value) {
-  m_value = std::move(value);
+libconfigfile::array_value_node::reference
+libconfigfile::array_value_node::at(size_type pos) {
+  return m_contents.at(pos);
+}
+
+libconfigfile::array_value_node::const_reference
+libconfigfile::array_value_node::at(size_type pos) const {
+  return m_contents.at(pos);
+}
+
+libconfigfile::array_value_node::reference
+libconfigfile::array_value_node::operator[](size_type pos) {
+  return m_contents[pos];
+}
+
+libconfigfile::array_value_node::const_reference
+libconfigfile::array_value_node::operator[](size_type pos) const {
+  return m_contents[pos];
+}
+
+libconfigfile::array_value_node::reference
+libconfigfile::array_value_node::front() {
+  return m_contents.front();
+}
+
+libconfigfile::array_value_node::const_reference
+libconfigfile::array_value_node::front() const {
+  return m_contents.front();
+}
+
+libconfigfile::array_value_node::reference
+libconfigfile::array_value_node::back() {
+  return m_contents.back();
+}
+
+libconfigfile::array_value_node::const_reference
+libconfigfile::array_value_node::back() const {
+  return m_contents.back();
+}
+
+libconfigfile::array_value_node::value_type *
+libconfigfile::array_value_node::data() {
+  return m_contents.data();
+}
+
+const libconfigfile::array_value_node::value_type *
+libconfigfile::array_value_node::data() const {
+  return m_contents.data();
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::begin() {
+  return m_contents.begin();
+}
+
+libconfigfile::array_value_node::const_iterator
+libconfigfile::array_value_node::begin() const {
+  return m_contents.begin();
+}
+
+libconfigfile::array_value_node::const_iterator
+libconfigfile::array_value_node::cbegin() const {
+  return m_contents.cbegin();
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::end() {
+  return m_contents.end();
+}
+
+libconfigfile::array_value_node::const_iterator
+libconfigfile::array_value_node::end() const {
+  return m_contents.end();
+}
+
+libconfigfile::array_value_node::const_iterator
+libconfigfile::array_value_node::cend() const {
+  return m_contents.cend();
+}
+
+libconfigfile::array_value_node::reverse_iterator
+libconfigfile::array_value_node::rbegin() {
+  return m_contents.rbegin();
+}
+
+libconfigfile::array_value_node::const_reverse_iterator
+libconfigfile::array_value_node::rbegin() const {
+  return m_contents.rbegin();
+}
+
+libconfigfile::array_value_node::const_reverse_iterator
+libconfigfile::array_value_node::crbegin() const {
+  return m_contents.crbegin();
+}
+
+libconfigfile::array_value_node::reverse_iterator
+libconfigfile::array_value_node::rend() {
+  return m_contents.rend();
+}
+
+libconfigfile::array_value_node::const_reverse_iterator
+libconfigfile::array_value_node::rend() const {
+  return m_contents.rend();
+}
+
+libconfigfile::array_value_node::const_reverse_iterator
+libconfigfile::array_value_node::crend() const {
+  return m_contents.crend();
+}
+
+bool libconfigfile::array_value_node::empty() const {
+  return m_contents.empty();
+}
+
+libconfigfile::array_value_node::size_type
+libconfigfile::array_value_node::size() const {
+  return m_contents.size();
+}
+
+libconfigfile::array_value_node::size_type
+libconfigfile::array_value_node::max_size() const {
+  return m_contents.max_size();
+}
+
+void libconfigfile::array_value_node::reserve(size_type new_cap) {
+  m_contents.reserve(new_cap);
+}
+
+libconfigfile::array_value_node::size_type
+libconfigfile::array_value_node::capacity() const {
+  return m_contents.capacity();
+}
+
+void libconfigfile::array_value_node::shrink_to_fit() {
+  m_contents.shrink_to_fit();
+}
+
+void libconfigfile::array_value_node::clear() { m_contents.clear(); }
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::insert(const_iterator pos,
+                                        const value_type &value) {
+  return m_contents.insert(pos, value);
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::insert(const_iterator pos,
+                                        value_type &&value) {
+  return m_contents.insert(pos, std::move(value));
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::insert(const_iterator pos, size_type count,
+                                        const value_type &value) {
+  return m_contents.insert(pos, count, value);
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::insert(
+    const_iterator pos, std::initializer_list<value_type> ilist) {
+  return m_contents.insert(pos, ilist);
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::erase(const_iterator pos) {
+  return m_contents.erase(pos);
+}
+
+libconfigfile::array_value_node::iterator
+libconfigfile::array_value_node::erase(const_iterator first,
+                                       const_iterator last) {
+  return m_contents.erase(first, last);
+}
+
+void libconfigfile::array_value_node::push_back(const value_type &value) {
+  m_contents.push_back(value);
+}
+
+void libconfigfile::array_value_node::push_back(value_type &&value) {
+  m_contents.push_back(std::move(value));
+}
+
+void libconfigfile::array_value_node::pop_back() { m_contents.pop_back(); }
+
+void libconfigfile::array_value_node::resize(size_type count) {
+  m_contents.resize(count);
+}
+
+void libconfigfile::array_value_node::resize(size_type count,
+                                             const value_type &value) {
+  m_contents.resize(count, value);
+}
+
+void libconfigfile::array_value_node::swap(array_value_node &other) {
+  m_contents.swap(other.m_contents);
 }
 
 libconfigfile::array_value_node &
@@ -68,34 +269,31 @@ libconfigfile::array_value_node::operator=(const array_value_node &other) {
     return *this;
   }
 
-  m_value = other.m_value;
+  m_contents = other.m_contents;
 
   return *this;
 }
 
 libconfigfile::array_value_node &
-libconfigfile::array_value_node::operator=(array_value_node &&other) {
+libconfigfile::array_value_node::operator=(array_value_node &&other) noexcept(
+    std::allocator_traits<
+        allocator_type>::propagate_on_container_move_assignment::value ||
+    std::allocator_traits<allocator_type>::is_always_equal::value) {
   if (this == &other) {
     return *this;
   }
 
-  m_value = std::move(other.m_value);
+  m_contents = std::move(other.m_contents);
 
   return *this;
 }
 
-libconfigfile::array_value_node &
-libconfigfile::array_value_node::operator=(const value_t &value) {
-  m_value = value;
-
-  return *this;
+bool libconfigfile::operator==(const array_value_node &lhs,
+                               const array_value_node &rhs) {
+  return lhs.m_contents == rhs.m_contents;
 }
 
-libconfigfile::array_value_node &
-libconfigfile::array_value_node::operator=(value_t &&value) {
-  m_value = std::move(value);
-
-  return *this;
+void libconfigfile::swap(array_value_node &lhs, array_value_node &rhs) {
+  using std::swap;
+  swap(lhs.m_contents, rhs.m_contents);
 }
-
-libconfigfile::array_value_node::operator value_t() const { return m_value; }

--- a/src/array_value_node.cpp
+++ b/src/array_value_node.cpp
@@ -4,7 +4,7 @@
 #include "node_types.hpp"
 #include "value_node.hpp"
 
-#include <cstddef>
+#include <initializer_list>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Add full complement of member functions to `array_value_node` to provide access to functionality of `std::vector`.