### PR TITLE
Revert removable of root table info from spec

### DIFF
--- a/configuration_file_syntax_specification.md
+++ b/configuration_file_syntax_specification.md
@@ -208,6 +208,7 @@ integers3 = [
 - Naming rules for sections are the same as for keys.
 - Empty sections are allowed and simply have no key-value pairs and/or sections within them.
 - The ordering of objects within a section is not preserved (for performance reasons).
+- The top-level section, also called the root section, starts at the beginning of the document and ends at end-of-file, encompassing everything else in its scope. Unlike other sections, it is nameless.
 ```
 (section)
 {


### PR DESCRIPTION
With the replacement of `config` by `section_node`, this is once again true.