### PR TITLE
`end_value_node` rework

### DIFF
--- a/include/end_value_node.hpp
+++ b/include/end_value_node.hpp
@@ -1,103 +1,21 @@
 #ifndef LIBCONFIGFILE_END_VALUE_NODE_HPP
 #define LIBCONFIGFILE_END_VALUE_NODE_HPP
 
-#include "node.hpp"
 #include "node_types.hpp"
 #include "value_node.hpp"
 
-#include <concepts>
-#include <cstdint>
-#include <string>
-#include <type_traits>
-#include <utility>
-
 namespace libconfigfile {
-
-using integer_end_value_node_t = int64_t;
-using float_end_value_node_t = double;
-using string_end_value_node_t = std::string;
-
-template <typename value_t>
-concept is_end_value_type = std::same_as<value_t, integer_end_value_node_t> ||
-                            std::same_as<value_t, float_end_value_node_t> ||
-                            std::same_as<value_t, string_end_value_node_t>;
-
-template <is_end_value_type value_t> class end_value_node : public value_node {
-private:
-  value_t m_value;
+class end_value_node : public value_node {
+public:
+  virtual ~end_value_node() override;
 
 public:
-  end_value_node() : m_value{} {}
-  explicit end_value_node(const value_t &value) : m_value{value} {}
-  explicit end_value_node(value_t &&value) : m_value{std::move(value)} {}
-  end_value_node(const end_value_node &other) : m_value{other.m_value} {}
-  end_value_node(end_value_node &&other) noexcept(
-      std::is_nothrow_move_constructible_v<value_t>)
-      : m_value{std::move(other.m_value)} {}
+  virtual end_value_node *create_new() const override = 0;
+  virtual end_value_node *create_clone() const override = 0;
+  virtual value_node_type get_value_node_type() const override final;
 
-  virtual ~end_value_node() override {}
-
-public:
-  virtual end_value_node *create_new() const override {
-    return new end_value_node<value_t>{};
-  }
-
-  virtual end_value_node *create_clone() const override {
-    return new end_value_node<value_t>{*this};
-  }
-
-  virtual value_node_type get_value_node_type() const override final {
-    return value_node_type::END_VALUE;
-  }
-
-  virtual end_value_node_type get_end_value_node_type() const {
-    return end_value_node_type::MAX;
-  }
-
-  const value_t &get() const { return m_value; }
-
-  value_t &get() { return m_value; }
-
-  void set(const value_t &value) { m_value = value; }
-
-  void set(value_t &&value) { m_value = std::move(value); }
-
-  end_value_node &operator=(const end_value_node &other) {
-    m_value = other.m_value;
-
-    return *this;
-  }
-
-  end_value_node &operator=(end_value_node &&other) noexcept(
-      std::is_nothrow_move_assignable_v<value_t>) {
-    m_value = std::move(other.m_value);
-
-    return *this;
-  }
-
-  end_value_node &operator=(const value_t &value) { m_value = value; }
-
-  end_value_node &operator=(value_t &&value) { m_value = std::move(value); }
+  virtual end_value_node_type get_end_value_node_type() const = 0;
 };
-
-template <>
-inline end_value_node_type
-end_value_node<integer_end_value_node_t>::get_end_value_node_type() const {
-  return end_value_node_type::INTEGER;
-}
-
-template <>
-inline end_value_node_type
-end_value_node<float_end_value_node_t>::get_end_value_node_type() const {
-  return end_value_node_type::FLOAT;
-}
-
-template <>
-inline end_value_node_type
-end_value_node<string_end_value_node_t>::get_end_value_node_type() const {
-  return end_value_node_type::STRING;
-}
-
 } // namespace libconfigfile
 
 #endif

--- a/include/float_end_value_node.hpp
+++ b/include/float_end_value_node.hpp
@@ -1,0 +1,48 @@
+#ifndef LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+#define LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <type_traits>
+
+namespace libconfigfile {
+
+using float_end_value_node_data_t = double;
+
+class float_end_value_node : public end_value_node {
+public:
+  using value_t = float_end_value_node_data_t;
+
+private:
+  value_t m_value;
+
+public:
+  float_end_value_node();
+  float_end_value_node(const value_t &value);
+  float_end_value_node(value_t &&value);
+  float_end_value_node(const float_end_value_node &other);
+  float_end_value_node(float_end_value_node &&other) noexcept(
+      std::is_nothrow_move_constructible_v<value_t>);
+
+  virtual ~float_end_value_node() override;
+
+public:
+  virtual float_end_value_node *create_new() const override;
+  virtual float_end_value_node *create_clone() const override;
+  virtual end_value_node_type get_end_value_node_type() const override;
+
+  const value_t &get() const;
+  value_t &get();
+  void set(const value_t &value);
+  void set(value_t &&value);
+
+  float_end_value_node &operator=(const float_end_value_node &other);
+  float_end_value_node &operator=(float_end_value_node &&other) noexcept(
+      std::is_nothrow_move_assignable_v<value_t>);
+  float_end_value_node &operator=(const value_t &value);
+  float_end_value_node &operator=(value_t &&value);
+};
+} // namespace libconfigfile
+
+#endif

--- a/include/integer_end_value_node.hpp
+++ b/include/integer_end_value_node.hpp
@@ -1,0 +1,49 @@
+#ifndef LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+#define LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <cstdint>
+#include <type_traits>
+
+namespace libconfigfile {
+
+using integer_end_value_node_data_t = int64_t;
+
+class integer_end_value_node : public end_value_node {
+public:
+  using value_t = integer_end_value_node_data_t;
+
+private:
+  value_t m_value;
+
+public:
+  integer_end_value_node();
+  integer_end_value_node(const value_t &value);
+  integer_end_value_node(value_t &&value);
+  integer_end_value_node(const integer_end_value_node &other);
+  integer_end_value_node(integer_end_value_node &&other) noexcept(
+      std::is_nothrow_move_constructible_v<value_t>);
+
+  virtual ~integer_end_value_node() override;
+
+public:
+  virtual integer_end_value_node *create_new() const override;
+  virtual integer_end_value_node *create_clone() const override;
+  virtual end_value_node_type get_end_value_node_type() const override;
+
+  const value_t &get() const;
+  value_t &get();
+  void set(const value_t &value);
+  void set(value_t &&value);
+
+  integer_end_value_node &operator=(const integer_end_value_node &other);
+  integer_end_value_node &operator=(integer_end_value_node &&other) noexcept(
+      std::is_nothrow_move_assignable_v<value_t>);
+  integer_end_value_node &operator=(const value_t &value);
+  integer_end_value_node &operator=(value_t &&value);
+};
+} // namespace libconfigfile
+
+#endif

--- a/include/string_end_value_node.hpp
+++ b/include/string_end_value_node.hpp
@@ -1,0 +1,49 @@
+#ifndef LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+#define LIBCONFIGFILE_INTEGER_END_VALUE_NODE
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <string>
+#include <type_traits>
+
+namespace libconfigfile {
+
+using string_end_value_node_data_t = std::string;
+
+class string_end_value_node : public end_value_node {
+public:
+  using value_t = string_end_value_node_data_t;
+
+private:
+  value_t m_value;
+
+public:
+  string_end_value_node();
+  string_end_value_node(const value_t &value);
+  string_end_value_node(value_t &&value);
+  string_end_value_node(const string_end_value_node &other);
+  string_end_value_node(string_end_value_node &&other) noexcept(
+      std::is_nothrow_move_constructible_v<value_t>);
+
+  virtual ~string_end_value_node() override;
+
+public:
+  virtual string_end_value_node *create_new() const override;
+  virtual string_end_value_node *create_clone() const override;
+  virtual end_value_node_type get_end_value_node_type() const override;
+
+  const value_t &get() const;
+  value_t &get();
+  void set(const value_t &value);
+  void set(value_t &&value);
+
+  string_end_value_node &operator=(const string_end_value_node &other);
+  string_end_value_node &operator=(string_end_value_node &&other) noexcept(
+      std::is_nothrow_move_assignable_v<value_t>);
+  string_end_value_node &operator=(const value_t &value);
+  string_end_value_node &operator=(value_t &&value);
+};
+} // namespace libconfigfile
+
+#endif

--- a/include/value_node.hpp
+++ b/include/value_node.hpp
@@ -4,8 +4,6 @@
 #include "node.hpp"
 #include "node_types.hpp"
 
-#include <cstddef>
-
 namespace libconfigfile {
 class value_node : public node {
 public:

--- a/src/end_value_node.cpp
+++ b/src/end_value_node.cpp
@@ -1,0 +1,11 @@
+#include "end_value_node.hpp"
+
+#include "node_types.hpp"
+#include "value_node.hpp"
+
+libconfigfile::end_value_node::~end_value_node() {}
+
+libconfigfile::value_node_type
+libconfigfile::end_value_node::get_value_node_type() const {
+  return value_node_type::END_VALUE;
+}

--- a/src/float_end_value_node.cpp
+++ b/src/float_end_value_node.cpp
@@ -1,0 +1,86 @@
+#include "float_end_value_node.hpp"
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <type_traits>
+#include <utility>
+
+libconfigfile::float_end_value_node::float_end_value_node() : m_value{} {}
+
+libconfigfile::float_end_value_node::float_end_value_node(const value_t &value)
+    : m_value{value} {}
+
+libconfigfile::float_end_value_node::float_end_value_node(value_t &&value)
+    : m_value{std::move(value)} {}
+
+libconfigfile::float_end_value_node::float_end_value_node(
+    const float_end_value_node &other)
+    : m_value{other.m_value} {}
+
+libconfigfile::float_end_value_node::float_end_value_node(
+    float_end_value_node
+        &&other) noexcept(std::is_nothrow_move_constructible_v<value_t>)
+    : m_value{std::move(other.m_value)} {}
+
+libconfigfile::float_end_value_node::~float_end_value_node() {}
+
+libconfigfile::float_end_value_node *
+libconfigfile::float_end_value_node::create_new() const {
+  return new float_end_value_node{};
+}
+
+libconfigfile::float_end_value_node *
+libconfigfile::float_end_value_node::create_clone() const {
+  return new float_end_value_node{*this};
+}
+
+libconfigfile::end_value_node_type
+libconfigfile::float_end_value_node::get_end_value_node_type() const {
+  return end_value_node_type::INTEGER;
+}
+
+const libconfigfile::float_end_value_node::value_t &
+libconfigfile::float_end_value_node::get() const {
+  return m_value;
+}
+
+libconfigfile::float_end_value_node::value_t &
+libconfigfile::float_end_value_node::get() {
+  return m_value;
+}
+
+void libconfigfile::float_end_value_node::set(const value_t &value) {
+  m_value = value;
+}
+
+void libconfigfile::float_end_value_node::set(value_t &&value) {
+  m_value = std::move(value);
+}
+
+libconfigfile::float_end_value_node &
+libconfigfile::float_end_value_node::operator=(
+    const float_end_value_node &other) {
+  m_value = other.m_value;
+  return *this;
+}
+
+libconfigfile::float_end_value_node &
+libconfigfile::float_end_value_node::operator=(
+    float_end_value_node
+        &&other) noexcept(std::is_nothrow_move_assignable_v<value_t>) {
+  m_value = std::move(other.m_value);
+  return *this;
+}
+
+libconfigfile::float_end_value_node &
+libconfigfile::float_end_value_node::operator=(const value_t &value) {
+  m_value = value;
+  return *this;
+}
+
+libconfigfile::float_end_value_node &
+libconfigfile::float_end_value_node::operator=(value_t &&value) {
+  m_value = std::move(value);
+  return *this;
+}

--- a/src/integer_end_value_node.cpp
+++ b/src/integer_end_value_node.cpp
@@ -1,0 +1,88 @@
+#include "integer_end_value_node.hpp"
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+libconfigfile::integer_end_value_node::integer_end_value_node() : m_value{} {}
+
+libconfigfile::integer_end_value_node::integer_end_value_node(
+    const value_t &value)
+    : m_value{value} {}
+
+libconfigfile::integer_end_value_node::integer_end_value_node(value_t &&value)
+    : m_value{std::move(value)} {}
+
+libconfigfile::integer_end_value_node::integer_end_value_node(
+    const integer_end_value_node &other)
+    : m_value{other.m_value} {}
+
+libconfigfile::integer_end_value_node::integer_end_value_node(
+    integer_end_value_node
+        &&other) noexcept(std::is_nothrow_move_constructible_v<value_t>)
+    : m_value{std::move(other.m_value)} {}
+
+libconfigfile::integer_end_value_node::~integer_end_value_node() {}
+
+libconfigfile::integer_end_value_node *
+libconfigfile::integer_end_value_node::create_new() const {
+  return new integer_end_value_node{};
+}
+
+libconfigfile::integer_end_value_node *
+libconfigfile::integer_end_value_node::create_clone() const {
+  return new integer_end_value_node{*this};
+}
+
+libconfigfile::end_value_node_type
+libconfigfile::integer_end_value_node::get_end_value_node_type() const {
+  return end_value_node_type::INTEGER;
+}
+
+const libconfigfile::integer_end_value_node::value_t &
+libconfigfile::integer_end_value_node::get() const {
+  return m_value;
+}
+
+libconfigfile::integer_end_value_node::value_t &
+libconfigfile::integer_end_value_node::get() {
+  return m_value;
+}
+
+void libconfigfile::integer_end_value_node::set(const value_t &value) {
+  m_value = value;
+}
+
+void libconfigfile::integer_end_value_node::set(value_t &&value) {
+  m_value = std::move(value);
+}
+
+libconfigfile::integer_end_value_node &
+libconfigfile::integer_end_value_node::operator=(
+    const integer_end_value_node &other) {
+  m_value = other.m_value;
+  return *this;
+}
+
+libconfigfile::integer_end_value_node &
+libconfigfile::integer_end_value_node::operator=(
+    integer_end_value_node
+        &&other) noexcept(std::is_nothrow_move_assignable_v<value_t>) {
+  m_value = std::move(other.m_value);
+  return *this;
+}
+
+libconfigfile::integer_end_value_node &
+libconfigfile::integer_end_value_node::operator=(const value_t &value) {
+  m_value = value;
+  return *this;
+}
+
+libconfigfile::integer_end_value_node &
+libconfigfile::integer_end_value_node::operator=(value_t &&value) {
+  m_value = std::move(value);
+  return *this;
+}

--- a/src/string_end_value_node.cpp
+++ b/src/string_end_value_node.cpp
@@ -1,0 +1,88 @@
+#include "string_end_value_node.hpp"
+
+#include "end_value_node.hpp"
+#include "node_types.hpp"
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+libconfigfile::string_end_value_node::string_end_value_node() : m_value{} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(
+    const value_t &value)
+    : m_value{value} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(value_t &&value)
+    : m_value{std::move(value)} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(
+    const string_end_value_node &other)
+    : m_value{other.m_value} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(
+    string_end_value_node
+        &&other) noexcept(std::is_nothrow_move_constructible_v<value_t>)
+    : m_value{std::move(other.m_value)} {}
+
+libconfigfile::string_end_value_node::~string_end_value_node() {}
+
+libconfigfile::string_end_value_node *
+libconfigfile::string_end_value_node::create_new() const {
+  return new string_end_value_node{};
+}
+
+libconfigfile::string_end_value_node *
+libconfigfile::string_end_value_node::create_clone() const {
+  return new string_end_value_node{*this};
+}
+
+libconfigfile::end_value_node_type
+libconfigfile::string_end_value_node::get_end_value_node_type() const {
+  return end_value_node_type::INTEGER;
+}
+
+const libconfigfile::string_end_value_node::value_t &
+libconfigfile::string_end_value_node::get() const {
+  return m_value;
+}
+
+libconfigfile::string_end_value_node::value_t &
+libconfigfile::string_end_value_node::get() {
+  return m_value;
+}
+
+void libconfigfile::string_end_value_node::set(const value_t &value) {
+  m_value = value;
+}
+
+void libconfigfile::string_end_value_node::set(value_t &&value) {
+  m_value = std::move(value);
+}
+
+libconfigfile::string_end_value_node &
+libconfigfile::string_end_value_node::operator=(
+    const string_end_value_node &other) {
+  m_value = other.m_value;
+  return *this;
+}
+
+libconfigfile::string_end_value_node &
+libconfigfile::string_end_value_node::operator=(
+    string_end_value_node
+        &&other) noexcept(std::is_nothrow_move_assignable_v<value_t>) {
+  m_value = std::move(other.m_value);
+  return *this;
+}
+
+libconfigfile::string_end_value_node &
+libconfigfile::string_end_value_node::operator=(const value_t &value) {
+  m_value = value;
+  return *this;
+}
+
+libconfigfile::string_end_value_node &
+libconfigfile::string_end_value_node::operator=(value_t &&value) {
+  m_value = std::move(value);
+  return *this;
+}

--- a/src/value_node.cpp
+++ b/src/value_node.cpp
@@ -3,9 +3,6 @@
 #include "node.hpp"
 #include "node_types.hpp"
 
-#include <cstddef>
-#include <utility>
-
 libconfigfile::value_node::~value_node() {}
 
 libconfigfile::node_type libconfigfile::value_node::get_node_type() const {


### PR DESCRIPTION
Rework `end_value_node` to be more consistent with rest of polymorphic node class hierarchy, rather than using templating.