### PR TITLE
Swap composition for inheritance in certain nodes

### DIFF
--- a/include/array_value_node.hpp
+++ b/include/array_value_node.hpp
@@ -6,42 +6,25 @@
 #include "node_types.hpp"
 #include "value_node.hpp"
 
-#include <initializer_list>
 #include <iostream>
-#include <memory>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace libconfigfile {
-class array_value_node : public value_node {
-public:
-  using vector_t = std::vector<node_ptr<value_node, true>>;
-  using value_type = vector_t::value_type;
-  using allocator_type = vector_t::allocator_type;
-  using size_type = vector_t::size_type;
-  using difference_type = vector_t::difference_type;
-  using reference = vector_t::reference;
-  using const_reference = vector_t::const_reference;
-  using pointer = vector_t::pointer;
-  using const_pointer = vector_t::const_pointer;
-  using iterator = vector_t::iterator;
-  using const_iterator = vector_t::const_iterator;
-  using reverse_iterator = vector_t::reverse_iterator;
-  using const_reverse_iterator = vector_t::const_reverse_iterator;
-
+class array_value_node : public value_node,
+                         public std::vector<node_ptr<value_node, true>> {
 private:
-  vector_t m_contents;
+  using base_t = std::vector<node_ptr<value_node, true>>;
 
 public:
+  using base_t::base_t;
   array_value_node();
-  explicit array_value_node(size_type count);
-  array_value_node(size_type count, const value_type &value);
-  template <typename InputIt>
-  array_value_node(InputIt first, InputIt last) : m_contents{first, last} {}
-  array_value_node(std::initializer_list<value_type> init);
   array_value_node(const array_value_node &other);
-  array_value_node(array_value_node &&other) noexcept;
+  array_value_node(array_value_node &&other) noexcept(
+      std::is_nothrow_move_constructible_v<base_t>);
+  array_value_node(const base_t &other);
+  array_value_node(base_t &&other) noexcept(
+      std::is_nothrow_move_constructible_v<base_t>);
 
   virtual ~array_value_node() override;
 
@@ -54,123 +37,16 @@ public:
   virtual void print(std::ostream &out) const override;
 
 public:
-  void assign(size_type count, const value_type &value);
-  template <typename InputIt> void assign(InputIt first, InputIt last) {
-    m_contents.assign(first, last);
-  }
-  void assign(std::initializer_list<value_type> ilist);
-  allocator_type get_allocator() const;
-
-  reference at(size_type pos);
-  const_reference at(size_type pos) const;
-  reference operator[](size_type pos);
-  const_reference operator[](size_type pos) const;
-  reference front();
-  const_reference front() const;
-  reference back();
-  const_reference back() const;
-  value_type *data();
-  const value_type *data() const;
-
-  iterator begin();
-  const_iterator begin() const;
-  const_iterator cbegin() const;
-  iterator end();
-  const_iterator end() const;
-  const_iterator cend() const;
-  reverse_iterator rbegin();
-  const_reverse_iterator rbegin() const;
-  const_reverse_iterator crbegin() const;
-  reverse_iterator rend();
-  const_reverse_iterator rend() const;
-  const_reverse_iterator crend() const;
-
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
-  void reserve(size_type new_cap);
-  size_type capacity() const;
-  void shrink_to_fit();
-
-  void clear();
-  iterator insert(const_iterator pos, const value_type &value);
-  iterator insert(const_iterator pos, value_type &&value);
-  iterator insert(const_iterator pos, size_type count, const value_type &value);
-  template <typename InputIt>
-  iterator insert(const_iterator pos, InputIt first, InputIt last) {
-    return m_contents.insert(pos, first, last);
-  }
-  iterator insert(const_iterator pos, std::initializer_list<value_type> ilist);
-  template <typename... Args>
-  iterator emplace(const_iterator pos, Args &&...args) {
-    return m_contents.emplace(pos, std::move(args...));
-  }
-  iterator erase(const_iterator pos);
-  iterator erase(const_iterator first, const_iterator last);
-  void push_back(const value_type &value);
-  void push_back(value_type &&value);
-  template <typename... Args> reference emplace_back(Args &&...args) {
-    return m_contents.emplace_back(std::move(args...));
-  }
-  void pop_back();
-  void resize(size_type count);
-  void resize(size_type count, const value_type &value);
-  void swap(array_value_node &other);
-
-public:
   array_value_node &operator=(const array_value_node &other);
   array_value_node &operator=(array_value_node &&other) noexcept(
-      std::allocator_traits<
-          allocator_type>::propagate_on_container_move_assignment::value ||
-      std::allocator_traits<allocator_type>::is_always_equal::value);
-  array_value_node &operator=(std::initializer_list<value_type> ilist);
+      std::is_nothrow_move_assignable_v<base_t>);
+  array_value_node &operator=(const base_t &other);
+  array_value_node &
+  operator=(base_t &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>);
 
 public:
-  friend bool operator==(const array_value_node &lhs,
-                         const array_value_node &rhs);
-  friend bool operator!=(const array_value_node &lhs,
-                         const array_value_node &rhs);
-  // friend bool operator<(const array_value_node &lhs,
-  //                       const array_value_node &rhs);
-  // friend bool operator<=(const array_value_node &lhs,
-  //                        const array_value_node &rhs);
-  // friend bool operator>(const array_value_node &lhs,
-  //                       const array_value_node &rhs);
-  // friend bool operator>=(const array_value_node &lhs,
-  //                        const array_value_node &rhs);
-  // friend auto operator<=>(const array_value_node &lhs,
-  //                         const array_value_node &rhs)
-  //     -> decltype(lhs.m_contents <=> rhs.m_contents);
-
-  friend void swap(array_value_node &lhs, array_value_node &rhs);
-  template <typename U>
-  friend array_value_node::size_type erase(array_value_node &c, const U &value);
-  template <typename Pred>
-  friend array_value_node::size_type erase_if(array_value_node &c, Pred pred);
-
   friend std::ostream &operator<<(std::ostream &out, const array_value_node &n);
 };
-
-bool operator==(const array_value_node &lhs, const array_value_node &rhs);
-bool operator!=(const array_value_node &lhs, const array_value_node &rhs);
-// bool operator<(const array_value_node &lhs, const array_value_node &rhs);
-// bool operator<=(const array_value_node &lhs, const array_value_node &rhs);
-// bool operator>(const array_value_node &lhs, const array_value_node &rhs);
-// bool operator>=(const array_value_node &lhs, const array_value_node &rhs);
-// auto operator<=>(const array_value_node &lhs, const array_value_node &rhs)
-//     -> decltype(lhs.m_contents <=> rhs.m_contents);
-
-void swap(array_value_node &lhs, array_value_node &rhs);
-template <typename U>
-array_value_node::size_type erase(array_value_node &c, const U &value) {
-  using std::erase;
-  return erase(c.m_contents, value);
-}
-template <typename Pred>
-array_value_node::size_type erase_if(array_value_node &c, Pred pred) {
-  using std::erase_if;
-  return erase_if(c, pred);
-}
 
 std::ostream &operator<<(std::ostream &out, const array_value_node &n);
 } // namespace libconfigfile

--- a/include/libconfigfile.hpp
+++ b/include/libconfigfile.hpp
@@ -2,6 +2,7 @@
 #define LIBCONFIGFILE_LIBCONFIGFILE_HPP
 
 #include "array_value_node.hpp"
+#include "character_constants.hpp"
 #include "end_value_node.hpp"
 #include "file.hpp"
 #include "float_end_value_node.hpp"

--- a/include/section_node.hpp
+++ b/include/section_node.hpp
@@ -5,52 +5,27 @@
 #include "node_ptr.hpp"
 #include "node_types.hpp"
 
-#include <initializer_list>
 #include <iostream>
-#include <memory>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
-#include <utility>
 
 namespace libconfigfile {
-class section_node : public node {
-public:
-  using unordered_map_t = std::unordered_map<std::string, node_ptr<node, true>>;
-  using key_type = unordered_map_t::key_type;
-  using mapped_type = unordered_map_t::mapped_type;
-  using value_type = unordered_map_t::value_type;
-  using size_type = unordered_map_t::size_type;
-  using difference_type = unordered_map_t::difference_type;
-  using hasher = unordered_map_t::hasher;
-  using key_equal = unordered_map_t::key_equal;
-  using allocator_type = unordered_map_t::allocator_type;
-  using reference = unordered_map_t::reference;
-  using const_reference = unordered_map_t::const_reference;
-  using pointer = unordered_map_t::pointer;
-  using const_pointer = unordered_map_t::const_pointer;
-  using iterator = unordered_map_t::iterator;
-  using const_iterator = unordered_map_t::const_iterator;
-  using local_iterator = unordered_map_t::local_iterator;
-  using const_local_iterator = unordered_map_t::const_local_iterator;
-  using map_node_type = unordered_map_t::node_type;
-  using insert_return_type = unordered_map_t::insert_return_type;
-
+class section_node
+    : public node,
+      public std::unordered_map<std::string, node_ptr<node, true>> {
 private:
-  unordered_map_t m_contents;
+  using base_t = std::unordered_map<std::string, node_ptr<node, true>>;
 
 public:
+  using base_t::base_t;
   section_node();
-  explicit section_node(size_type bucket_count);
-  template <typename InputIt>
-  section_node(InputIt first, InputIt last) : m_contents{first, last} {}
-  template <typename InputIt>
-  section_node(InputIt first, InputIt last, size_type bucket_count)
-      : m_contents{first, last, bucket_count} {}
-  section_node(std::initializer_list<value_type> init);
-  section_node(std::initializer_list<value_type> init, size_type bucket_count);
   section_node(const section_node &other);
-  section_node(section_node &&other);
+  section_node(section_node &&other) noexcept(
+      std::is_nothrow_move_constructible_v<base_t>);
+  section_node(const base_t &other);
+  section_node(base_t &&other) noexcept(
+      std::is_nothrow_move_constructible_v<base_t>);
 
   virtual ~section_node() override;
 
@@ -63,171 +38,16 @@ public:
   virtual void print(std::ostream &out) const override;
 
 public:
-  allocator_type get_allocator() const;
-
-  iterator begin();
-  const_iterator begin() const;
-  const_iterator cbegin() const;
-  iterator end();
-  const_iterator end() const;
-  const_iterator cend() const;
-
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
-
-  void clear();
-  std::pair<iterator, bool> insert(const value_type &value);
-  std::pair<iterator, bool> insert(value_type &&value);
-  template <typename P>
-  std::enable_if<std::is_constructible<value_type, P &&>::value,
-                 std::pair<iterator, bool>>
-  insert(P &&value) {
-    return m_contents.insert(std::move(value));
-  }
-  iterator insert(const_iterator hint, const value_type &value);
-  iterator insert(const_iterator hint, value_type &&value);
-  template <typename P>
-  std::enable_if<std::is_constructible<value_type, P &&>::value, iterator>
-  insert(const_iterator hint, P &&value) {
-    return m_contents.insert(hint, std::move(value));
-  }
-  template <typename InputIt> void insert(InputIt first, InputIt last) {
-    m_contents.insert(first, last);
-  }
-  void insert(std::initializer_list<value_type> ilist);
-  insert_return_type insert(map_node_type &&nh);
-  iterator insert(const_iterator hint, map_node_type &&nh);
-  template <typename M>
-  std::pair<iterator, bool> insert_or_assign(const key_type &k, M &&obj) {
-    return m_contents.insert_or_assign(k, std::move(obj));
-  }
-  template <typename M>
-  std::pair<iterator, bool> insert_or_assign(key_type &&k, M &&obj) {
-    return m_contents.insert_or_assign(std::move(k), std::move(obj));
-  }
-  template <typename M>
-  iterator insert_or_assign(const_iterator hint, const key_type &k, M &&obj) {
-    return m_contents.insert_or_assign(hint, k, std::move(obj));
-  }
-  template <typename M>
-  iterator insert_or_assign(const_iterator hint, key_type &&k, M &&obj) {
-    return m_contents.insert_or_assign(hint, std::move(k), std::move(obj));
-  }
-  template <typename... Args>
-  std::pair<iterator, bool> emplace(Args &&...args) {
-    return m_contents.emplace(std::move(args...));
-  }
-  template <typename... Args>
-  iterator emplace_hint(const_iterator hint, Args &&...args) {
-    return m_contents.emplace(hint, std::move(args...));
-  }
-  template <typename... Args>
-  std::pair<iterator, bool> try_emplace(const key_type &k, Args &&...args) {
-    return m_contents.try_emplace(k, std::move(args...));
-  }
-  template <typename... Args>
-  std::pair<iterator, bool> try_emplace(key_type &&k, Args &&...args) {
-    return m_contents.try_emplace(std::move(k), std::move(args...));
-  }
-  template <typename... Args>
-  iterator try_emplace(const_iterator hint, const key_type &k, Args &&...args) {
-    return m_contents.try_emplace(hint, k, std::move(args...));
-  }
-  template <typename... Args>
-  iterator try_emplace(const_iterator hint, key_type &&k, Args &&...args) {
-    return m_contents.try_emplace(hint, std::move(k), std::move(args...));
-  }
-  iterator erase(const_iterator pos);
-  iterator erase(const_iterator first, const_iterator last);
-  size_type erase(const key_type &k);
-  void swap(section_node &other);
-  map_node_type extract(const_iterator position);
-  map_node_type extract(const key_type &k);
-  void merge(section_node &source);
-  void merge(section_node &&source);
-
-  mapped_type &at(const key_type &key);
-  const mapped_type &at(const key_type &key) const;
-  mapped_type &operator[](const key_type &key);
-  mapped_type &operator[](key_type &&key);
-  size_type count(const key_type &key) const;
-  template <typename K>
-  auto count(const K &x) const -> decltype(m_contents.count(x)) {
-    return m_contents.count(x);
-  }
-  iterator find(const key_type &key);
-  const_iterator find(const key_type &key) const;
-  template <typename K> auto find(const K &x) -> decltype(m_contents.find(x)) {
-    return m_contents.find(x);
-  }
-  template <typename K>
-  auto find(const K &x) const -> decltype(m_contents.find(x)) {
-    return m_contents.find(x);
-  }
-  bool contains(const key_type &key) const;
-  template <typename K>
-  auto contains(const K &x) const -> decltype(m_contents.contains(x)) {
-    return m_contents.contains(x);
-  }
-  std::pair<iterator, iterator> equal_range(const key_type &key);
-  std::pair<const_iterator, const_iterator>
-  equal_range(const key_type &key) const;
-  template <typename K>
-  auto equal_range(const K &x) -> decltype(m_contents.equal_range(x)) {
-    return m_contents.equal_range(x);
-  }
-  template <typename K>
-  auto equal_range(const K &x) const -> decltype(m_contents.equal_range(x)) {
-    return m_contents.equal_range(x);
-  }
-
-  local_iterator begin(size_type n);
-  const_local_iterator begin(size_type n) const;
-  const_local_iterator cbegin(size_type n) const;
-  local_iterator end(size_type n);
-  const_local_iterator end(size_type n) const;
-  const_local_iterator cend(size_type n) const;
-  size_type bucket_count() const;
-  size_type max_bucket_count() const;
-  size_type bucket_size(size_type n) const;
-  size_type bucket(const key_type &key) const;
-
-  float load_factor() const;
-  float max_load_factor() const;
-  void max_load_factor(float ml);
-  void rehash(size_type count);
-  void reserve(size_type count);
-
-  hasher hash_function() const;
-  key_equal key_eq() const;
-
-public:
   section_node &operator=(const section_node &other);
   section_node &operator=(section_node &&other) noexcept(
-      std::is_nothrow_assignable_v<decltype(m_contents), decltype(m_contents)>);
+      std::is_nothrow_move_assignable_v<base_t>);
+  section_node &operator=(const base_t &other);
+  section_node &
+  operator=(base_t &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>);
 
 public:
-  friend bool operator==(const section_node &lhs, const section_node &rhs);
-  friend bool operator!=(const section_node &lhs, const section_node &rhs);
-
-  friend void swap(section_node &lhs, section_node &rhs);
-  template <typename Pred>
-  friend size_type erase_if(section_node &c, Pred pred);
-
   friend std::ostream &operator<<(std::ostream &out, const section_node &n);
 };
-
-bool operator==(const section_node &lhs, const section_node &rhs);
-bool operator!=(const section_node &lhs, const section_node &rhs);
-
-void swap(section_node &lhs, section_node &rhs);
-
-template <typename Pred>
-section_node::size_type erase_if(section_node &c, Pred pred) {
-  using std::erase_if;
-  return erase_if(c.m_contents, pred);
-}
 
 std::ostream &operator<<(std::ostream &out, const section_node &n);
 } // namespace libconfigfile

--- a/include/string_end_value_node.hpp
+++ b/include/string_end_value_node.hpp
@@ -10,22 +10,19 @@
 
 namespace libconfigfile {
 
-using string_end_value_node_data_t = std::string;
-
-class string_end_value_node : public end_value_node {
-public:
-  using value_t = string_end_value_node_data_t;
-
+class string_end_value_node : public end_value_node, std::string {
 private:
-  value_t m_value;
+  using base_t = std::string;
 
 public:
+  using base_t::base_t;
   string_end_value_node();
-  string_end_value_node(const value_t &value);
-  string_end_value_node(value_t &&value);
   string_end_value_node(const string_end_value_node &other);
   string_end_value_node(string_end_value_node &&other) noexcept(
-      std::is_nothrow_move_constructible_v<value_t>);
+      std::is_nothrow_move_constructible_v<base_t>);
+  string_end_value_node(const base_t &other);
+  string_end_value_node(base_t &&other) noexcept(
+      std::is_nothrow_move_constructible_v<base_t>);
 
   virtual ~string_end_value_node() override;
 
@@ -38,29 +35,17 @@ public:
   virtual void print(std::ostream &out) const override;
 
 public:
-  const value_t &get() const;
-  value_t &get();
-  void set(const value_t &value);
-  void set(value_t &&value);
-
   string_end_value_node &operator=(const string_end_value_node &other);
   string_end_value_node &operator=(string_end_value_node &&other) noexcept(
-      std::is_nothrow_move_assignable_v<value_t>);
-  string_end_value_node &operator=(const value_t &value);
-  string_end_value_node &operator=(value_t &&value);
+      std::is_nothrow_move_assignable_v<base_t>);
+  string_end_value_node &operator=(const base_t &other);
+  string_end_value_node &
+  operator=(base_t &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>);
 
 public:
-  friend bool operator==(const string_end_value_node &x,
-                         const string_end_value_node &y);
-  friend bool operator!=(const string_end_value_node &x,
-                         const string_end_value_node &y);
-
   friend std::ostream &operator<<(std::ostream &out,
                                   const string_end_value_node &n);
 };
-
-bool operator==(const string_end_value_node &x, const string_end_value_node &y);
-bool operator!=(const string_end_value_node &x, const string_end_value_node &y);
 
 std::ostream &operator<<(std::ostream &out, const string_end_value_node &n);
 } // namespace libconfigfile

--- a/src/array_value_node.cpp
+++ b/src/array_value_node.cpp
@@ -2,35 +2,30 @@
 
 #include "character_constants.hpp"
 #include "node.hpp"
+#include "node_ptr.hpp"
 #include "node_types.hpp"
 #include "value_node.hpp"
 
-#include <algorithm>
-#include <initializer_list>
 #include <iostream>
-#include <memory>
-#include <utility>
+#include <type_traits>
 #include <vector>
 
-libconfigfile::array_value_node::array_value_node() : m_contents{} {}
-
-libconfigfile::array_value_node::array_value_node(size_type count)
-    : m_contents{count} {}
-
-libconfigfile::array_value_node::array_value_node(size_type count,
-                                                  const value_type &value)
-    : m_contents{count, value} {}
-
-libconfigfile::array_value_node::array_value_node(
-    std::initializer_list<value_type> init)
-    : m_contents{init} {}
+libconfigfile::array_value_node::array_value_node() : base_t{} {}
 
 libconfigfile::array_value_node::array_value_node(const array_value_node &other)
-    : m_contents{other.m_contents} {}
+    : base_t{other} {}
 
 libconfigfile::array_value_node::array_value_node(
-    array_value_node &&other) noexcept
-    : m_contents{std::move(other.m_contents)} {}
+    array_value_node
+        &&other) noexcept(std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
+
+libconfigfile::array_value_node::array_value_node(const base_t &other)
+    : base_t{other} {}
+
+libconfigfile::array_value_node::array_value_node(base_t &&other) noexcept(
+    std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
 
 libconfigfile::array_value_node::~array_value_node() {}
 
@@ -66,10 +61,10 @@ bool libconfigfile::array_value_node::polymorphic_value_compare(
 void libconfigfile::array_value_node::print(std::ostream &out) const {
   out << character_constants::g_k_array_opening_delimiter;
 
-  for (auto p{m_contents.begin()}; p != m_contents.end(); ++p) {
+  for (auto p{this->begin()}; p != this->end(); ++p) {
     out << (*p);
 
-    if ((p + 1) != m_contents.end()) {
+    if ((p + 1) != this->end()) {
       out << character_constants::g_k_array_element_separator;
     }
   }
@@ -77,274 +72,29 @@ void libconfigfile::array_value_node::print(std::ostream &out) const {
   out << character_constants::g_k_array_closing_delimiter;
 }
 
-void libconfigfile::array_value_node::assign(size_type count,
-                                             const value_type &value) {
-  m_contents.assign(count, value);
-}
-
-void libconfigfile::array_value_node::assign(
-    std::initializer_list<value_type> ilist) {
-  m_contents.assign(ilist);
-}
-
-libconfigfile::array_value_node::allocator_type
-libconfigfile::array_value_node::get_allocator() const {
-  return m_contents.get_allocator();
-}
-
-libconfigfile::array_value_node::reference
-libconfigfile::array_value_node::at(size_type pos) {
-  return m_contents.at(pos);
-}
-
-libconfigfile::array_value_node::const_reference
-libconfigfile::array_value_node::at(size_type pos) const {
-  return m_contents.at(pos);
-}
-
-libconfigfile::array_value_node::reference
-libconfigfile::array_value_node::operator[](size_type pos) {
-  return m_contents[pos];
-}
-
-libconfigfile::array_value_node::const_reference
-libconfigfile::array_value_node::operator[](size_type pos) const {
-  return m_contents[pos];
-}
-
-libconfigfile::array_value_node::reference
-libconfigfile::array_value_node::front() {
-  return m_contents.front();
-}
-
-libconfigfile::array_value_node::const_reference
-libconfigfile::array_value_node::front() const {
-  return m_contents.front();
-}
-
-libconfigfile::array_value_node::reference
-libconfigfile::array_value_node::back() {
-  return m_contents.back();
-}
-
-libconfigfile::array_value_node::const_reference
-libconfigfile::array_value_node::back() const {
-  return m_contents.back();
-}
-
-libconfigfile::array_value_node::value_type *
-libconfigfile::array_value_node::data() {
-  return m_contents.data();
-}
-
-const libconfigfile::array_value_node::value_type *
-libconfigfile::array_value_node::data() const {
-  return m_contents.data();
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::begin() {
-  return m_contents.begin();
-}
-
-libconfigfile::array_value_node::const_iterator
-libconfigfile::array_value_node::begin() const {
-  return m_contents.begin();
-}
-
-libconfigfile::array_value_node::const_iterator
-libconfigfile::array_value_node::cbegin() const {
-  return m_contents.cbegin();
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::end() {
-  return m_contents.end();
-}
-
-libconfigfile::array_value_node::const_iterator
-libconfigfile::array_value_node::end() const {
-  return m_contents.end();
-}
-
-libconfigfile::array_value_node::const_iterator
-libconfigfile::array_value_node::cend() const {
-  return m_contents.cend();
-}
-
-libconfigfile::array_value_node::reverse_iterator
-libconfigfile::array_value_node::rbegin() {
-  return m_contents.rbegin();
-}
-
-libconfigfile::array_value_node::const_reverse_iterator
-libconfigfile::array_value_node::rbegin() const {
-  return m_contents.rbegin();
-}
-
-libconfigfile::array_value_node::const_reverse_iterator
-libconfigfile::array_value_node::crbegin() const {
-  return m_contents.crbegin();
-}
-
-libconfigfile::array_value_node::reverse_iterator
-libconfigfile::array_value_node::rend() {
-  return m_contents.rend();
-}
-
-libconfigfile::array_value_node::const_reverse_iterator
-libconfigfile::array_value_node::rend() const {
-  return m_contents.rend();
-}
-
-libconfigfile::array_value_node::const_reverse_iterator
-libconfigfile::array_value_node::crend() const {
-  return m_contents.crend();
-}
-
-bool libconfigfile::array_value_node::empty() const {
-  return m_contents.empty();
-}
-
-libconfigfile::array_value_node::size_type
-libconfigfile::array_value_node::size() const {
-  return m_contents.size();
-}
-
-libconfigfile::array_value_node::size_type
-libconfigfile::array_value_node::max_size() const {
-  return m_contents.max_size();
-}
-
-void libconfigfile::array_value_node::reserve(size_type new_cap) {
-  m_contents.reserve(new_cap);
-}
-
-libconfigfile::array_value_node::size_type
-libconfigfile::array_value_node::capacity() const {
-  return m_contents.capacity();
-}
-
-void libconfigfile::array_value_node::shrink_to_fit() {
-  m_contents.shrink_to_fit();
-}
-
-void libconfigfile::array_value_node::clear() { m_contents.clear(); }
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::insert(const_iterator pos,
-                                        const value_type &value) {
-  return m_contents.insert(pos, value);
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::insert(const_iterator pos,
-                                        value_type &&value) {
-  return m_contents.insert(pos, std::move(value));
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::insert(const_iterator pos, size_type count,
-                                        const value_type &value) {
-  return m_contents.insert(pos, count, value);
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::insert(
-    const_iterator pos, std::initializer_list<value_type> ilist) {
-  return m_contents.insert(pos, ilist);
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::erase(const_iterator pos) {
-  return m_contents.erase(pos);
-}
-
-libconfigfile::array_value_node::iterator
-libconfigfile::array_value_node::erase(const_iterator first,
-                                       const_iterator last) {
-  return m_contents.erase(first, last);
-}
-
-void libconfigfile::array_value_node::push_back(const value_type &value) {
-  m_contents.push_back(value);
-}
-
-void libconfigfile::array_value_node::push_back(value_type &&value) {
-  m_contents.push_back(std::move(value));
-}
-
-void libconfigfile::array_value_node::pop_back() { m_contents.pop_back(); }
-
-void libconfigfile::array_value_node::resize(size_type count) {
-  m_contents.resize(count);
-}
-
-void libconfigfile::array_value_node::resize(size_type count,
-                                             const value_type &value) {
-  m_contents.resize(count, value);
-}
-
-void libconfigfile::array_value_node::swap(array_value_node &other) {
-  m_contents.swap(other.m_contents);
-}
-
 libconfigfile::array_value_node &
 libconfigfile::array_value_node::operator=(const array_value_node &other) {
-  m_contents = other.m_contents;
-
+  base_t::operator=(other);
   return *this;
 }
 
 libconfigfile::array_value_node &
 libconfigfile::array_value_node::operator=(array_value_node &&other) noexcept(
-    std::allocator_traits<
-        allocator_type>::propagate_on_container_move_assignment::value ||
-    std::allocator_traits<allocator_type>::is_always_equal::value) {
-  m_contents = std::move(other.m_contents);
-
+    std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
   return *this;
 }
 
-bool libconfigfile::operator==(const array_value_node &lhs,
-                               const array_value_node &rhs) {
-  return (lhs.m_contents == rhs.m_contents);
+libconfigfile::array_value_node &
+libconfigfile::array_value_node::operator=(const base_t &other) {
+  base_t::operator=(other);
+  return *this;
 }
 
-bool libconfigfile::operator!=(const array_value_node &lhs,
-                               const array_value_node &rhs) {
-  return (lhs.m_contents == rhs.m_contents);
-}
-
-// bool libconfigfile::operator<(const array_value_node &lhs,
-//                               const array_value_node &rhs) {
-//   return lhs.m_contents < rhs.m_contents;
-// }
-//
-// bool libconfigfile::operator<=(const array_value_node &lhs,
-//                                const array_value_node &rhs) {
-//   return lhs.m_contents <= rhs.m_contents;
-// }
-//
-// bool libconfigfile::operator>(const array_value_node &lhs,
-//                               const array_value_node &rhs) {
-//   return lhs.m_contents > rhs.m_contents;
-// }
-//
-// bool libconfigfile::operator>=(const array_value_node &lhs,
-//                                const array_value_node &rhs) {
-//   return lhs.m_contents >= rhs.m_contents;
-// }
-//
-// auto libconfigfile::operator<=>(const array_value_node &lhs,
-//                                 const array_value_node &rhs)
-//     -> decltype(lhs.m_contents <=> rhs.m_contents) {
-//   return lhs.m_contents <=> rhs.m_contents;
-// }
-
-void libconfigfile::swap(array_value_node &lhs, array_value_node &rhs) {
-  using std::swap;
-  swap(lhs.m_contents, rhs.m_contents);
+libconfigfile::array_value_node &libconfigfile::array_value_node::operator=(
+    base_t &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
+  return *this;
 }
 
 std::ostream &libconfigfile::operator<<(std::ostream &out,

--- a/src/section_node.cpp
+++ b/src/section_node.cpp
@@ -2,35 +2,32 @@
 
 #include "character_constants.hpp"
 #include "node.hpp"
+#include "node_ptr.hpp"
 #include "node_types.hpp"
 
-#include <initializer_list>
 #include <iostream>
-#include <memory>
+#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
 
-libconfigfile::section_node::section_node() : m_contents{} {}
-
-libconfigfile::section_node::section_node(size_type bucket_count)
-    : m_contents{bucket_count} {}
-
-libconfigfile::section_node::section_node(
-    std::initializer_list<value_type> init)
-    : m_contents{init} {}
-
-libconfigfile::section_node::section_node(
-    std::initializer_list<value_type> init, size_type bucket_count)
-    : m_contents{init, bucket_count} {}
+libconfigfile::section_node::section_node() : base_t{} {}
 
 libconfigfile::section_node::section_node(const section_node &other)
-    : m_contents{other.m_contents} {}
+    : base_t{other} {}
 
-libconfigfile::section_node::section_node(section_node &&other)
-    : m_contents{std::move(other.m_contents)} {}
+libconfigfile::section_node::section_node(section_node &&other) noexcept(
+    std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
 
-libconfigfile::section_node::~section_node() {}
+libconfigfile::section_node::section_node(const base_t &other)
+    : base_t{other} {}
+
+libconfigfile::section_node::section_node(base_t &&other) noexcept(
+    std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
+
+libconfigfile::section_node::~section_node(){};
 
 libconfigfile::section_node *libconfigfile::section_node::create_new() const {
   return new section_node{};
@@ -59,7 +56,7 @@ bool libconfigfile::section_node::polymorphic_value_compare(
 }
 
 void libconfigfile::section_node::print(std::ostream &out) const {
-  for (auto p{m_contents.begin()}; p != m_contents.end(); ++p) {
+  for (auto p{this->begin()}; p != this->end(); ++p) {
 
     switch ((*p).second->get_absolute_node_type()) {
 
@@ -81,285 +78,28 @@ void libconfigfile::section_node::print(std::ostream &out) const {
   }
 }
 
-libconfigfile::section_node::allocator_type
-libconfigfile::section_node::get_allocator() const {
-  return m_contents.get_allocator();
-}
-
-libconfigfile::section_node::iterator libconfigfile::section_node::begin() {
-  return m_contents.begin();
-}
-
-libconfigfile::section_node::const_iterator
-libconfigfile::section_node::begin() const {
-  return m_contents.begin();
-}
-
-libconfigfile::section_node::const_iterator
-libconfigfile::section_node::cbegin() const {
-  return m_contents.cbegin();
-}
-
-libconfigfile::section_node::iterator libconfigfile::section_node::end() {
-  return m_contents.end();
-}
-
-libconfigfile::section_node::const_iterator
-libconfigfile::section_node::end() const {
-  return m_contents.end();
-}
-
-libconfigfile::section_node::const_iterator
-libconfigfile::section_node::cend() const {
-  return m_contents.cend();
-}
-
-bool libconfigfile::section_node::empty() const { return m_contents.empty(); }
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::size() const {
-  return m_contents.size();
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::max_size() const {
-  return m_contents.max_size();
-}
-
-void libconfigfile::section_node::clear() { m_contents.clear(); }
-
-std::pair<libconfigfile::section_node::iterator, bool>
-libconfigfile::section_node::insert(const value_type &value) {
-  return m_contents.insert(value);
-}
-
-std::pair<libconfigfile::section_node::iterator, bool>
-libconfigfile::section_node::insert(value_type &&value) {
-  return m_contents.insert(std::move(value));
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::insert(const_iterator hint,
-                                    const value_type &value) {
-  return m_contents.insert(hint, value);
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::insert(const_iterator hint, value_type &&value) {
-  return m_contents.insert(hint, std::move(value));
-}
-
-void libconfigfile::section_node::insert(
-    std::initializer_list<value_type> ilist) {
-  m_contents.insert(ilist);
-}
-
-libconfigfile::section_node::insert_return_type
-libconfigfile::section_node::insert(map_node_type &&nh) {
-  return m_contents.insert(std::move(nh));
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::insert(const_iterator hint, map_node_type &&nh) {
-  return m_contents.insert(hint, std::move(nh));
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::erase(const_iterator pos) {
-  return m_contents.erase(pos);
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::erase(const_iterator first, const_iterator last) {
-  return m_contents.erase(first, last);
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::erase(const key_type &k) {
-  return m_contents.erase(k);
-}
-
-void libconfigfile::section_node::swap(section_node &other) {
-  m_contents.swap(other.m_contents);
-}
-
-libconfigfile::section_node::map_node_type
-libconfigfile::section_node::extract(const_iterator position) {
-  return m_contents.extract(position);
-}
-
-libconfigfile::section_node::map_node_type
-libconfigfile::section_node::extract(const key_type &k) {
-  return m_contents.extract(k);
-}
-
-void libconfigfile::section_node::merge(section_node &other) {
-  m_contents.merge(other.m_contents);
-}
-
-void libconfigfile::section_node::merge(section_node &&other) {
-  m_contents.merge(std::move(other.m_contents));
-}
-
-libconfigfile::section_node::mapped_type &
-libconfigfile::section_node::at(const key_type &key) {
-  return m_contents.at(key);
-}
-
-const libconfigfile::section_node::mapped_type &
-libconfigfile::section_node::at(const key_type &key) const {
-  return m_contents.at(key);
-}
-
-libconfigfile::section_node::mapped_type &
-libconfigfile::section_node::operator[](const key_type &key) {
-  return m_contents[key];
-}
-
-libconfigfile::section_node::mapped_type &
-libconfigfile::section_node::operator[](key_type &&key) {
-  return m_contents[std::move(key)];
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::count(const key_type &key) const {
-  return m_contents.count(key);
-}
-
-libconfigfile::section_node::iterator
-libconfigfile::section_node::find(const key_type &key) {
-  return m_contents.find(key);
-}
-
-libconfigfile::section_node::const_iterator
-libconfigfile::section_node::find(const key_type &key) const {
-  return m_contents.find(key);
-}
-
-bool libconfigfile::section_node::contains(const key_type &key) const {
-  return m_contents.contains(key);
-}
-
-std::pair<libconfigfile::section_node::iterator,
-          libconfigfile::section_node::iterator>
-libconfigfile::section_node::equal_range(const key_type &key) {
-  return m_contents.equal_range(key);
-}
-
-std::pair<libconfigfile::section_node::const_iterator,
-          libconfigfile::section_node::const_iterator>
-libconfigfile::section_node::equal_range(const key_type &key) const {
-  return m_contents.equal_range(key);
-}
-
-libconfigfile::section_node::local_iterator
-libconfigfile::section_node::begin(size_type n) {
-  return m_contents.begin(n);
-}
-
-libconfigfile::section_node::const_local_iterator
-libconfigfile::section_node::begin(size_type n) const {
-  return m_contents.begin(n);
-}
-
-libconfigfile::section_node::const_local_iterator
-libconfigfile::section_node::cbegin(size_type n) const {
-  return m_contents.cbegin(n);
-}
-
-libconfigfile::section_node::local_iterator
-libconfigfile::section_node::end(size_type n) {
-  return m_contents.end(n);
-}
-
-libconfigfile::section_node::const_local_iterator
-libconfigfile::section_node::end(size_type n) const {
-  return m_contents.end(n);
-}
-
-libconfigfile::section_node::const_local_iterator
-libconfigfile::section_node::cend(size_type n) const {
-  return m_contents.cend(n);
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::bucket_count() const {
-  return m_contents.bucket_count();
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::max_bucket_count() const {
-  return m_contents.max_bucket_count();
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::bucket_size(size_type n) const {
-  return m_contents.bucket_size(n);
-}
-
-libconfigfile::section_node::size_type
-libconfigfile::section_node::bucket(const key_type &key) const {
-  return m_contents.bucket(key);
-}
-
-float libconfigfile::section_node::load_factor() const {
-  return m_contents.load_factor();
-}
-
-float libconfigfile::section_node::max_load_factor() const {
-  return m_contents.max_load_factor();
-}
-
-void libconfigfile::section_node::max_load_factor(float ml) {
-  m_contents.max_load_factor(ml);
-}
-
-void libconfigfile::section_node::rehash(size_type count) {
-  m_contents.rehash(count);
-}
-
-void libconfigfile::section_node::reserve(size_type count) {
-  m_contents.reserve(count);
-}
-
-libconfigfile::section_node::hasher
-libconfigfile::section_node::hash_function() const {
-  return m_contents.hash_function();
-}
-
-libconfigfile::section_node::key_equal
-libconfigfile::section_node::key_eq() const {
-  return m_contents.key_eq();
-}
-
 libconfigfile::section_node &
 libconfigfile::section_node::operator=(const section_node &other) {
-  m_contents = other.m_contents;
+  base_t::operator=(other);
+  return *this;
+}
 
+libconfigfile::section_node &libconfigfile::section_node::operator=(
+    section_node &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
   return *this;
 }
 
 libconfigfile::section_node &
-libconfigfile::section_node::operator=(section_node &&other) noexcept(
-    std::is_nothrow_assignable_v<decltype(m_contents), decltype(m_contents)>) {
-  m_contents = std::move(other.m_contents);
-
+libconfigfile::section_node::operator=(const base_t &other) {
+  base_t::operator=(other);
   return *this;
 }
 
-bool libconfigfile::operator==(const section_node &lhs,
-                               const section_node &rhs) {
-  return (lhs.m_contents == rhs.m_contents);
-}
-
-bool libconfigfile::operator!=(const section_node &lhs,
-                               const section_node &rhs) {
-  return (lhs.m_contents == rhs.m_contents);
-}
-
-void libconfigfile::swap(section_node &lhs, section_node &rhs) {
-  using std::swap;
-  swap(lhs.m_contents, rhs.m_contents);
+libconfigfile::section_node &libconfigfile::section_node::operator=(
+    base_t &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
+  return *this;
 }
 
 std::ostream &libconfigfile::operator<<(std::ostream &out,

--- a/src/string_end_value_node.cpp
+++ b/src/string_end_value_node.cpp
@@ -7,25 +7,24 @@
 #include <iostream>
 #include <string>
 #include <type_traits>
-#include <utility>
 
-libconfigfile::string_end_value_node::string_end_value_node() : m_value{} {}
-
-libconfigfile::string_end_value_node::string_end_value_node(
-    const value_t &value)
-    : m_value{value} {}
-
-libconfigfile::string_end_value_node::string_end_value_node(value_t &&value)
-    : m_value{std::move(value)} {}
+libconfigfile::string_end_value_node::string_end_value_node() : base_t{} {}
 
 libconfigfile::string_end_value_node::string_end_value_node(
     const string_end_value_node &other)
-    : m_value{other.m_value} {}
+    : base_t{other} {}
 
 libconfigfile::string_end_value_node::string_end_value_node(
     string_end_value_node
-        &&other) noexcept(std::is_nothrow_move_constructible_v<value_t>)
-    : m_value{std::move(other.m_value)} {}
+        &&other) noexcept(std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(const base_t &other)
+    : base_t{other} {}
+
+libconfigfile::string_end_value_node::string_end_value_node(
+    base_t &&other) noexcept(std::is_nothrow_move_constructible_v<base_t>)
+    : base_t{std::move(other)} {}
 
 libconfigfile::string_end_value_node::~string_end_value_node() {}
 
@@ -59,63 +58,36 @@ bool libconfigfile::string_end_value_node::polymorphic_value_compare(
 }
 
 void libconfigfile::string_end_value_node::print(std::ostream &out) const {
-  out << character_constants::g_k_string_delimiter << m_value
+  out << character_constants::g_k_string_delimiter << *this
       << character_constants::g_k_string_delimiter;
-}
-
-const libconfigfile::string_end_value_node::value_t &
-libconfigfile::string_end_value_node::get() const {
-  return m_value;
-}
-
-libconfigfile::string_end_value_node::value_t &
-libconfigfile::string_end_value_node::get() {
-  return m_value;
-}
-
-void libconfigfile::string_end_value_node::set(const value_t &value) {
-  m_value = value;
-}
-
-void libconfigfile::string_end_value_node::set(value_t &&value) {
-  m_value = std::move(value);
 }
 
 libconfigfile::string_end_value_node &
 libconfigfile::string_end_value_node::operator=(
     const string_end_value_node &other) {
-  m_value = other.m_value;
+  base_t::operator=(other);
   return *this;
 }
 
 libconfigfile::string_end_value_node &
 libconfigfile::string_end_value_node::operator=(
     string_end_value_node
-        &&other) noexcept(std::is_nothrow_move_assignable_v<value_t>) {
-  m_value = std::move(other.m_value);
+        &&other) noexcept(std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
   return *this;
 }
 
 libconfigfile::string_end_value_node &
-libconfigfile::string_end_value_node::operator=(const value_t &value) {
-  m_value = value;
+libconfigfile::string_end_value_node::operator=(const base_t &other) {
+  base_t::operator=(other);
   return *this;
 }
 
 libconfigfile::string_end_value_node &
-libconfigfile::string_end_value_node::operator=(value_t &&value) {
-  m_value = std::move(value);
+libconfigfile::string_end_value_node::operator=(base_t &&other) noexcept(
+    std::is_nothrow_move_assignable_v<base_t>) {
+  base_t::operator=(std::move(other));
   return *this;
-}
-
-bool libconfigfile::operator==(const string_end_value_node &x,
-                               const string_end_value_node &y) {
-  return ((x.get()) == (y.get()));
-}
-
-bool libconfigfile::operator!=(const string_end_value_node &x,
-                               const string_end_value_node &y) {
-  return ((x.get()) == (y.get()));
 }
 
 std::ostream &libconfigfile::operator<<(std::ostream &out,


### PR DESCRIPTION
For node classes implementing the interface of standard library classes (section_node, array_value_node, string_end_value_node), simplify the class definition by inheriting from standard library base class rather than containing data member and creating forwarding functions. This is ok as long as the derived class does not contain any data (as in our case).