### PR TITLE
Generalize parser input streams using templates

### DIFF
--- a/include/integer_end_value_node.hpp
+++ b/include/integer_end_value_node.hpp
@@ -26,8 +26,8 @@ private:
 
 public:
   integer_end_value_node();
-  integer_end_value_node(
-      const value_t value, const numeral_system *num_sys = &numeral_system_decimal);
+  integer_end_value_node(const value_t value, const numeral_system *num_sys =
+                                                  &numeral_system_decimal);
   integer_end_value_node(const integer_end_value_node &other);
   integer_end_value_node(integer_end_value_node &&other) noexcept(
       std::is_nothrow_move_constructible_v<value_t>);

--- a/include/numeral_system.hpp
+++ b/include/numeral_system.hpp
@@ -18,8 +18,8 @@ public:
   constexpr ~numeral_system(){};
 
 public:
-  constexpr numeral_system(const int a_base, const char a_prefix, const char a_prefix_alt,
-                           std::string_view a_digits)
+  constexpr numeral_system(const int a_base, const char a_prefix,
+                           const char a_prefix_alt, std::string_view a_digits)
       : base{a_base}, prefix{a_prefix},
         prefix_alt{a_prefix_alt}, digits{a_digits} {}
 

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -27,16 +27,22 @@
 
 namespace libconfigfile {
 namespace parser {
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
 node_ptr<section_node> parse(const std::string &identifier,
-                             std::istream &input_stream,
+                             t_input_stream &input_stream,
                              const bool identifier_is_file_path = false);
 node_ptr<section_node> parse_file(const std::filesystem::path &file_path);
 
 namespace impl {
 
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
 struct context {
   std::string identifier;
-  std::istream &input_stream;
+  t_input_stream &input_stream;
   bool identifier_is_file_path;
   long long line_count;
   long long char_count;
@@ -48,49 +54,101 @@ enum class directive {
   include,
 };
 
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
 node_ptr<section_node> parse(const std::string &identifier,
-                             std::istream &input_stream,
+                             t_input_stream &input_stream,
                              const bool identifier_is_file_path = false);
 
-std::pair<std::string, node_ptr<section_node>>
-parse_section(context &ctx, const bool is_root_section = false);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+std::pair<std::string, node_ptr<section_node>> parse_section(
+    context<t_input_stream> &ctx, const bool is_root_section = false);
 
-std::pair<std::string, node_ptr<value_node>> parse_key_value(context &ctx);
-std::string parse_key_value_key(context &ctx);
-node_ptr<value_node> parse_key_value_value(context &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+std::pair<std::string, node_ptr<value_node>> parse_key_value(
+    context<t_input_stream> &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+std::string parse_key_value_key(context<t_input_stream> &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<value_node> parse_key_value_value(context<t_input_stream> &ctx);
 
-node_ptr<array_value_node>
-parse_array_value(context &ctx, const std::string &possible_terminating_chars,
-                  char *actual_terminating_char = nullptr);
-node_ptr<integer_end_value_node>
-parse_integer_value(context &ctx, const std::string &possible_terminating_chars,
-                    char *actual_terminating_char = nullptr);
-node_ptr<float_end_value_node>
-parse_float_value(context &ctx, const std::string &possible_terminating_chars,
-                  char *actual_terminating_char = nullptr);
-node_ptr<string_end_value_node>
-parse_string_value(context &ctx, const std::string &possible_terminating_chars,
-                   char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<array_value_node> parse_array_value(
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
+    char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<integer_end_value_node> parse_integer_value(
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
+    char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<float_end_value_node> parse_float_value(
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
+    char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<string_end_value_node> parse_string_value(
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
+    char *actual_terminating_char = nullptr);
 
-node_ptr<value_node>
-call_appropriate_value_parse_func(context &ctx,
-                                  const std::string &possible_terminating_chars,
-                                  char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<value_node> call_appropriate_value_parse_func(
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
+    char *actual_terminating_char = nullptr);
 
-std::pair<directive, std::optional<node_ptr<section_node>>>
-parse_directive(context &ctx);
-void parse_version_directive(context &ctx);
-node_ptr<section_node> parse_include_directive(context &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+std::pair<directive, std::optional<node_ptr<section_node>>> parse_directive(
+    context<t_input_stream> &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+void parse_version_directive(context<t_input_stream> &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+node_ptr<section_node> parse_include_directive(context<t_input_stream> &ctx);
 
-bool handle_comments(context &ctx);
-char handle_escape_sequence(context &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>)) bool
+handle_comments(context<t_input_stream> &ctx);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+char handle_escape_sequence(context<t_input_stream> &ctx);
 
-std::variant<value_node_type, end_value_node_type>
-identify_key_value_value_type(context &ctx,
-                              const std::string &possible_terminating_chars,
-                              char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
+std::
+    variant<value_node_type, end_value_node_type> identify_key_value_value_type(
+        context<t_input_stream> &ctx,
+        const std::string &possible_terminating_chars,
+        char *actual_terminating_char = nullptr);
+template <typename t_input_stream>
+  requires((std::same_as<t_input_stream, std::istream>) ||
+           (std::derived_from<t_input_stream, std::istream>))
 end_value_node_type identify_key_value_numeric_value_type(
-    context &ctx, const std::string &possible_terminating_chars,
+    context<t_input_stream> &ctx, const std::string &possible_terminating_chars,
     char *actual_terminating_char = nullptr);
 
 std::variant<std::string /*result*/,
@@ -137,7 +195,8 @@ std::pair<bool, std::string::size_type>
 contains_invalid_character_invalid_provided(const std::string &str,
                                             const std::string &invalid_chars);
 
-bool is_digit(const char ch, const numeral_system &num_sys = numeral_system_decimal);
+bool is_digit(const char ch,
+              const numeral_system &num_sys = numeral_system_decimal);
 
 bool case_insensitive_char_compare(const char ch1, const char ch2);
 bool case_insensitive_string_compare(const std::string &str1,

--- a/src/integer_end_value_node.cpp
+++ b/src/integer_end_value_node.cpp
@@ -63,7 +63,7 @@ bool libconfigfile::integer_end_value_node::polymorphic_value_compare(
 std::ostream &
 libconfigfile::integer_end_value_node::print(std::ostream &out) const {
 
-  std::ostreambuf_iterator<char> const out_iter{out};
+  const std::ostreambuf_iterator<char> out_iter{out};
 
   switch (m_num_sys->base) {
   case numeral_system_decimal.base: {


### PR DESCRIPTION
More robust and portable when comparing to polymorphism approach Also remove explicit reference to `std::ifstream`